### PR TITLE
add code to generate grpc files within slam

### DIFF
--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -1,3 +1,18 @@
+
+# Temp fix for building grpc, grab minimal rdk and build locally
+pull-rdk: bufsetup pull-rdk.sh
+	./pull-rdk.sh
+	cd rdk-minimal && PATH="${PATH}:`pwd`/../grpc/bin" buf generate --template ../buf.gen.yaml
+	cd rdk-minimal && PATH="${PATH}:`pwd`/../grpc/bin" buf generate --template ../buf.grpc.gen.yaml
+	cd rdk-minimal && PATH="${PATH}:`pwd`/../grpc/bin" buf generate --template ../buf.gen.yaml buf.build/googleapis/googleapis
+
+bufsetup:
+	sudo apt-get install -y protobuf-compiler-grpc libgrpc-dev libgrpc++-dev || brew install grpc openssl --quiet
+	GOBIN=`pwd`/grpc/bin go install github.com/bufbuild/buf/cmd/buf@v1.4.0
+	ln -sf `which grpc_cpp_plugin` grpc/bin/protoc-gen-grpc-cpp
+	pkg-config openssl || export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:`find \`which brew > /dev/null && brew --prefix\` -name openssl.pc | head -n1 | xargs dirname`
+
+
 format:
 	find . -type f -not -path \
 		-and ! -path '*viam-cartographer/cartographer*' \
@@ -5,3 +20,4 @@ format:
 		-and ! -path '*viam-orb-slam3/ORB_SLAM3*' \
 		-and \( -iname '*.h' -o -iname '*.cpp' -o -iname '*.cc' \) \
 		| xargs clang-format -i --style="{BasedOnStyle: Google, IndentWidth: 4}"
+

--- a/slam-libraries/buf.gen.yaml
+++ b/slam-libraries/buf.gen.yaml
@@ -1,0 +1,4 @@
+version: v1beta1
+plugins:
+  - name: cpp
+    out: grpc/cpp/gen

--- a/slam-libraries/buf.grpc.gen.yaml
+++ b/slam-libraries/buf.grpc.gen.yaml
@@ -1,0 +1,4 @@
+version: v1beta1
+plugins:
+  - name: grpc-cpp
+    out: grpc/cpp/gen

--- a/slam-libraries/pull-rdk.sh
+++ b/slam-libraries/pull-rdk.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# If it already exists, just update
+if [ -d rdk-minimal/ ]
+then
+	cd rdk-minimal
+	git pull origin main
+else
+	mkdir rdk-minimal
+	cd rdk-minimal
+	git init -b main
+	git remote add origin git@github.com:viamrobotics/rdk.git
+	git config pull.ff only
+	git fetch --depth=1 origin main
+	git sparse-checkout set --cone "grpc/cpp" "proto" "buf.yaml" "buf.lock" "go.mod" "go.sum"
+	git pull origin main
+fi
+
+

--- a/slam-libraries/viam-orb-slam3/CMakeLists.txt
+++ b/slam-libraries/viam-orb-slam3/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
 if(DEFINED ENV{RDK_SOURCE_DIR})
   set(RDK_SOURCE_DIR $ENV{RDK_SOURCE_DIR})
 else()
-  set(RDK_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../../../rdk)
+  set(RDK_SOURCE_DIR ${PROJECT_SOURCE_DIR}/../rdk-minimal)
 endif()
 
 set(SRCDIR ${RDK_SOURCE_DIR}/grpc/cpp/gen)


### PR DESCRIPTION
Quick setup to generate c++ grpc files for use with slam. pulls a minimal copy of rdk into slam 