### PR TITLE
[DATA-298] Reserve port in slam process

### DIFF
--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -793,12 +793,13 @@ int main(int argc, char **argv) {
         slamService.offlineFlag = true;
     }
 
-    builder.AddListeningPort(slam_port, grpc::InsecureServerCredentials());
+    std::unique_ptr<int> selected_port = std::make_unique<int>(0);
+    builder.AddListeningPort(slam_port, grpc::InsecureServerCredentials(), selected_port.get());
     builder.RegisterService(&slamService);
 
     // Start the SLAM gRPC server
     std::unique_ptr<Server> server(builder.BuildAndStart());
-    BOOST_LOG_TRIVIAL(info) << "Server listening on " << slam_port.c_str();
+    BOOST_LOG_TRIVIAL(info) << "Server listening on " << *selected_port;
 
     // Determine which settings file to use(.yaml)
     const path myPath(path_to_settings);


### PR DESCRIPTION
There are 3 PRs necessary to reserve the port in the slam process:

https://github.com/viamrobotics/slam/pull/29 (this PR): orbslam reserves and logs the port
https://github.com/viamrobotics/goutils/pull/50: add support for extracting log lines from managed processes
https://github.com/viamrobotics/rdk/pull/1269: slam service reads port from orbslam logs

https://github.com/viamrobotics/rdk/pull/1269 must be merged after https://github.com/viamrobotics/slam/pull/29 and https://github.com/viamrobotics/goutils/pull/50.