### PR TITLE
Fix bugs: offline mode and saving maps w/o keypoints

### DIFF
--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -564,19 +564,16 @@ void SLAMServiceImpl::save_atlas_as_osa_with_timestamp(
             }
             return;
         }
-        bool could_not_save_map = false;
         if (SLAM->GetAtlas()->GetCurrentMap()->GetAllKeyFrames().size() != 0) {
             std::lock_guard<std::mutex> lock(slam_mutex);
             SLAM->SaveAtlasAsOsaWithTimestamp(path_save_file_name);
-        } else {
-            could_not_save_map = true;
         }
         // Sleep for map_rate_sec duration, but check frequently for
         // shutdown
         while (b_continue_session) {
             std::chrono::duration<double, std::milli> time_elapsed_msec =
                 std::chrono::high_resolution_clock::now() - start;
-            if (time_elapsed_msec >= map_rate_sec || could_not_save_map) {
+            if (time_elapsed_msec >= map_rate_sec) {
                 break;
             }
             if (map_rate_sec - time_elapsed_msec >=


### PR DESCRIPTION
This PR fixes two bugs:

1. In offline mode, we need to grab the closest file instead of the most recent one
2. When saving maps, the pre-save function would label any maps without keypoints as "bad". Doing that on the current map breaks the process of using that map and adding keypoints to it.