### PR TITLE
only update the pose when the tracking state is ok

### DIFF
--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -423,11 +423,12 @@ void SLAMServiceImpl::ProcessDataOnline(ORB_SLAM3::System *SLAM) {
                 currMap->GetAllKeyFrames();
             {
                 std::lock_guard<std::mutex> lock(slam_mutex);
-                poseGrpc = tmpPose;
                 if (SLAM->GetTrackingState() ==
-                        ORB_SLAM3::Tracking::eTrackingState::OK &&
-                    nkeyframes != keyframes.size()) {
-                    currMapPoints = currMap->GetAllMapPoints();
+                    ORB_SLAM3::Tracking::eTrackingState::OK) {
+                    poseGrpc = tmpPose;
+                    if (nkeyframes != keyframes.size()) {
+                        currMapPoints = currMap->GetAllMapPoints();
+                    }
                 }
             }
             BOOST_LOG_TRIVIAL(debug) << "Passed image to SLAM";
@@ -502,11 +503,12 @@ void SLAMServiceImpl::ProcessDataOffline(ORB_SLAM3::System *SLAM) {
                 currMap->GetAllKeyFrames();
             {
                 std::lock_guard<std::mutex> lock(slam_mutex);
-                poseGrpc = tmpPose;
                 if (SLAM->GetTrackingState() ==
-                        ORB_SLAM3::Tracking::eTrackingState::OK &&
-                    nkeyframes != keyframes.size()) {
-                    currMapPoints = currMap->GetAllMapPoints();
+                    ORB_SLAM3::Tracking::eTrackingState::OK) {
+                    poseGrpc = tmpPose;
+                    if (nkeyframes != keyframes.size()) {
+                        currMapPoints = currMap->GetAllMapPoints();
+                    }
                 }
             }
             nkeyframes = keyframes.size();


### PR DESCRIPTION
I'm pretty sure this is the bug, since the returned pose is empty when the tracking state is not ok.

I also added debugging and used ProcessDataForTesting to see if the way we're extracting the pose from the `Sophus::SE3f` is correct, and that all looks fine, so I think this is probably the issue.