### PR TITLE
add libdl to app image

### DIFF
--- a/slam-libraries/packaging/appimages/orb_grpc_server-aarch64.yml
+++ b/slam-libraries/packaging/appimages/orb_grpc_server-aarch64.yml
@@ -21,7 +21,7 @@ AppDir:
     id: com.viam.orb_grpc_server
     name: orb_grpc_server
     icon: viam-server
-    version: testing
+    version: latest
     exec: usr/bin/aix
     exec_args: $@
   apt:

--- a/slam-libraries/packaging/appimages/orb_grpc_server-x86_64.yml
+++ b/slam-libraries/packaging/appimages/orb_grpc_server-x86_64.yml
@@ -22,7 +22,7 @@ AppDir:
     id: com.viam.orb_grpc_server
     name: orb_grpc_server
     icon: viam-server
-    version: testing
+    version: latest
     exec: usr/bin/aix
     exec_args: $@
   apt:


### PR DESCRIPTION
This did appear to fix the integrations tests in rdk. However, I also accidentally updated the orbslam app image for everyone. I tried to deploy the app image to a different location in this job, so that I could test it out: https://github.com/viamrobotics/slam/actions/runs/3160904170/jobs/5145969859. But it looks like it still deployed to gs://packages.viam.com/apps/slam-servers/orb_grpc_server-latest-x86_64.AppImage.zsync. However, now I see that integration tests on the main branch in rdk are passing: https://github.com/viamrobotics/rdk/actions/runs/3161017009/jobs/5146129585. 