### PR TITLE
[DATA-548] Add stable release channel for orbslam binary

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -71,7 +71,7 @@ jobs:
         sudo -u testbot bash -lc 'cd slam/slam-libraries && make testorb'
 
     - name: Build appimage
-      run: sudo -u testbot bash -lc 'cd slam/slam-libraries && make appimage'
+      run: sudo -u testbot bash -lc 'cd slam/slam-libraries && make BUILD_CHANNEL="latest" appimage'
 
     - name: Authorize GCP Upload
       uses: google-github-actions/auth@v0.4.3

--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -1,3 +1,4 @@
+BUILD_CHANNEL?=local
 
 bufsetup:
 	sudo apt-get install -y protobuf-compiler-grpc libgrpc-dev libgrpc++-dev || brew install grpc openssl --quiet
@@ -46,7 +47,8 @@ orbslam-all: buf setuporb buildorb testorb
 
 
 appimage: buildorb
-	cd packaging/appimages && appimage-builder --recipe orb_grpc_server-`uname -m`.yml
+	cd packaging/appimages && BUILD_CHANNEL=${BUILD_CHANNEL} appimage-builder --recipe orb_grpc_server-`uname -m`.yml
+	cd packaging/appimages && ./package_release.sh
 	mkdir -p packaging/appimages/deploy/
 	mv packaging/appimages/*.AppImage* packaging/appimages/deploy/
 	chmod 755 packaging/appimages/deploy/*.AppImage

--- a/slam-libraries/packaging/appimages/orb_grpc_server-aarch64.yml
+++ b/slam-libraries/packaging/appimages/orb_grpc_server-aarch64.yml
@@ -21,7 +21,7 @@ AppDir:
     id: com.viam.orb_grpc_server
     name: orb_grpc_server
     icon: viam-server
-    version: latest
+    version: ${BUILD_CHANNEL}
     exec: usr/bin/aix
     exec_args: $@
   apt:
@@ -85,4 +85,4 @@ AppDir:
         AIX_TARGET: usr/bin/orb_grpc_server
 AppImage:
   arch: aarch64
-  update-information: zsync|http://packages.viam.com/apps/slam-servers/orb_grpc_server-latest-aarch64.AppImage.zsync
+  update-information: zsync|http://packages.viam.com/apps/slam-servers/orb_grpc_server-${BUILD_CHANNEL}-aarch64.AppImage.zsync

--- a/slam-libraries/packaging/appimages/orb_grpc_server-x86_64.yml
+++ b/slam-libraries/packaging/appimages/orb_grpc_server-x86_64.yml
@@ -22,7 +22,7 @@ AppDir:
     id: com.viam.orb_grpc_server
     name: orb_grpc_server
     icon: viam-server
-    version: latest
+    version: ${BUILD_CHANNEL}
     exec: usr/bin/aix
     exec_args: $@
   apt:
@@ -77,4 +77,4 @@ AppDir:
         AIX_TARGET: usr/bin/orb_grpc_server
 AppImage:
   arch: x86_64
-  update-information: zsync|http://packages.viam.com/apps/slam-servers/orb_grpc_server-latest-x86_64.AppImage.zsync
+  update-information: zsync|http://packages.viam.com/apps/slam-servers/orb_grpc_server-${BUILD_CHANNEL}-x86_64.AppImage.zsync

--- a/slam-libraries/packaging/appimages/package_release.sh
+++ b/slam-libraries/packaging/appimages/package_release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+SELF=$(realpath $0)
+source "$(dirname $SELF)/utils.sh"
+
+if get_version_tag > /dev/null
+then
+	CUR_TAG=$(get_version_tag)
+	BUILD_CHANNEL=stable appimage-builder --recipe orb_grpc_server-`uname -m`.yml
+	BUILD_CHANNEL=$CUR_TAG appimage-builder --recipe orb_grpc_servers-`uname -m`.yml
+fi

--- a/slam-libraries/packaging/appimages/utils.sh
+++ b/slam-libraries/packaging/appimages/utils.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a helper function to determine if the current git commit constitutes a new release.
+# Specifically, is it tagged in the format "v1.2.3" and a higher version than any other tags.
+# This is used for internal tagging and release building.
+get_version_tag() {
+	set -e
+	CUR_TAG=`git tag --points-at | sort -Vr | head -n1`
+	if [[ $CUR_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+	then
+		NEWEST_TAG=`git tag -l "v*.*.*" | sort -Vr | head -n1`
+		if [[ $CUR_TAG == $NEWEST_TAG ]]
+		then
+			echo $CUR_TAG
+			return 0
+		else
+			echo "latest"
+			return 128
+		fi
+	fi
+	return 1
+}


### PR DESCRIPTION
I'm not sure I can test this until we actually tag the first version, which we don't want to do until https://viam.atlassian.net/browse/DATA-542 is fixed.