### PR TITLE
[DATA-580] Set up a github action to build cartographer and add make targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,4 @@ jobs:
     uses: viamrobotics/slam/.github/workflows/appimage.yml@DATA-580
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   appimage:
-    uses: viamrobotics/slam/.github/workflows/appimage.yml@DATA-580
+    uses: viamrobotics/slam/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,5 @@ jobs:
     uses: viamrobotics/slam/.github/workflows/appimage.yml@DATA-580
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ on:
 
 jobs:
   appimage:
-    uses: viamrobotics/slam/.github/workflows/appimage.yml@main
+    uses: viamrobotics/slam/.github/workflows/appimage.yml@DATA-580
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/slam/.github/workflows/test.yml@main
+    uses: viamrobotics/slam/.github/workflows/test.yml@DATA-580
     secrets:
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,6 +16,6 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/slam/.github/workflows/test.yml@DATA-580
+    uses: viamrobotics/slam/.github/workflows/test.yml@main
     secrets:
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,4 +18,5 @@ jobs:
   test:
     uses: viamrobotics/slam/.github/workflows/test.yml@DATA-580
     secrets:
+      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,5 +18,4 @@ jobs:
   test:
     uses: viamrobotics/slam/.github/workflows/test.yml@DATA-580
     secrets:
-      REPO_READ_TOKEN: ${{ secrets.REPO_READ_TOKEN }}
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS: ${{ secrets.ARTIFACT_READ_ONLY_GCP_CREDENTIALS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 2
 
     - name: Check modified files
       id: check_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,9 @@ jobs:
       id: check_files
       run: |
         echo "Listing modified files..."
-        git diff --name-only `git merge-base --fork-point refs/remotes/origin/main`
+        git diff --name-only `git merge-base --fork-point origin/main`
         echo "Check paths of modified files..."
-        git diff --name-only `git merge-base --fork-point refs/remotes/origin/main` > files.txt
+        git diff --name-only `git merge-base --fork-point origin/main` > files.txt
         echo "::set-output name=run_carto::false"
         echo "::set-output name=run_orb::false"
         while IFS= read -r file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         git fetch origin main
         echo "Listing modified files..."
-        git merge-base --fork-point origin/main
+        echo $(git merge-base --fork-point origin/main)
         git diff $(git merge-base --fork-point origin/main)
         echo "Check paths of modified files..."
         git diff $(git merge-base --fork-point origin/main) > files.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
+      REPO_READ_TOKEN:
+        required: true
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS:
         required: true
 
@@ -107,6 +109,10 @@ jobs:
     timeout-minutes: 180
 
     steps:
+    - name: Configure git for private repos
+      run: |
+        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
+
     - name: Check out code in slam directory
       uses: actions/checkout@v3
       with:
@@ -179,6 +185,10 @@ jobs:
       with:
         submodules: recursive
         path: slam
+
+    - name: Configure git for private repos
+      run: |
+        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
 
     - name: make setupcarto
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
             exit 1
         fi
 
-check_modified_files:
+  check_modified_files:
     name: Check modified files
     outputs:
       run_carto: ${{ steps.check_files.outputs.run_carto }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      REPO_READ_TOKEN:
-        required: true
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS:
         required: true
 
@@ -14,8 +12,74 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS_FILENAME: "google-credentials.json"
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  format:
+    name: Format
+    runs-on: [x64, qemu-host]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: --platform linux/amd64
+    timeout-minutes: 30
+    steps:
+    - name: Check out code in slam directory
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Verify no uncommitted changes from make format
+      run: |
+        git init
+        git add .
+        chown -R testbot .
+        sudo -u testbot bash -lc 'cd slam-libraries && make format-setup format'
+        GEN_DIFF=$(git status -s)
+
+        if [ -n "$GEN_DIFF" ]; then
+            echo '"make format" resulted in changes not in git' 1>&2
+            git status
+            exit 1
+        fi
+
+check_modified_files:
+    name: Check modified files
+    outputs:
+      run_carto: ${{ steps.check_files.outputs.run_carto }}
+      run_orb: ${{ steps.check_files.outputs.run_orb }}
+    runs-on: [x64, qemu-host]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: --platform linux/amd64
+    timeout-minutes: 30
+    steps:
+    - name: Check out code in slam directory
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Check modified files
+      id: check_files
+      run: |
+        echo "Listing modified files..."
+        git diff --name-only HEAD^ HEAD
+        echo "Check paths of modified files..."
+        git diff --name-only HEAD^ HEAD &gt; files.txt
+        echo "::set-output name=run_carto::false"
+        echo "::set-output name=run_orb::false"
+        while IFS= read -r file
+        do
+          echo $file
+          if [[ $file != slam-libraries/viam-orb-slam3/* ]]; then
+            echo "This modified file is not under 'viam-orb-slam3'"
+            echo "::set-output name=run_carto::true"
+          fi
+          if [[ $file != slam-libraries/viam-cartographer/* ]]; then
+            echo "This modified file is not under 'viam-cartographer'"
+            echo "::set-output name=run_orb::true"
+          fi
+
+  build_and_test_orb:
+    name: Build and Test Orbslam
+    needs: check_modified_files
+    if: needs.check_modified_files.outputs.run_orb == 'true'
     strategy:
       matrix:
         include:
@@ -32,30 +96,11 @@ jobs:
     timeout-minutes: 180
 
     steps:
-    - name: Configure git for private repos
-      run: |
-        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
-
     - name: Check out code in slam directory
       uses: actions/checkout@v3
       with:
         submodules: recursive
         path: slam
-
-    - name: Verify no uncommitted changes from make format
-      run: |
-        cd slam
-        git init
-        git add .
-        chown -R testbot .
-        sudo -u testbot bash -lc 'cd slam-libraries && make format-setup format'
-        GEN_DIFF=$(git status -s)
-
-        if [ -n "$GEN_DIFF" ]; then
-            echo '"make format" resulted in changes not in git' 1>&2
-            git status
-            exit 1
-        fi
 
     - name: make buf
       timeout-minutes: 5
@@ -97,3 +142,37 @@ jobs:
       if: matrix.platform == 'linux/amd64'
       run: |
         sudo --preserve-env=GOOGLE_APPLICATION_CREDENTIALS -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -run TestOrbslamIntegration'
+
+  build_and_test_cartographer:
+    name: Build and Test Cartographer
+    needs: check_modified_files
+    if: needs.check_modified_files.outputs.run_carto == 'true'
+    strategy:
+      matrix:
+        include:
+          - arch: [x64, qemu-host]
+            image: ghcr.io/viamrobotics/canon:amd64-cache
+            platform: linux/amd64
+          - arch: [arm64, qemu-host]
+            image: ghcr.io/viamrobotics/canon:arm64-cache
+            platform: linux/arm64
+    runs-on: ${{ matrix.arch }}
+    container:
+      image: ${{ matrix.image }}
+      options: --platform ${{ matrix.platform }}
+    timeout-minutes: 180
+
+    steps:
+    - name: Check out code in slam directory
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        path: slam
+
+    - name: make setupcarto
+      run: |
+        sudo -u testbot bash -lc 'cd slam/slam-libraries && make setupcarto'
+
+    - name: make buildcarto
+      run: |
+        sudo -u testbot bash -lc 'cd slam/slam-libraries && make buildcarto'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Check modified files
       id: check_files
       run: |
+        git fetch origin main
         echo "Listing modified files..."
         git diff --name-only `git merge-base --fork-point origin/main`
         echo "Check paths of modified files..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,11 +73,14 @@ jobs:
           case $file in 
             slam-libraries/viam-cartographer/*)
               echo "run_carto=true" >> $GITHUB_OUTPUT
+              ;;
             slam-libraries/viam-orb-slam4/*)
               echo "run_orb=true" >> $GITHUB_OUTPUT
+              ;;
             *)
               echo "run_orb=true" >> $GITHUB_OUTPUT
               echo "run_carto=true" >> $GITHUB_OUTPUT
+              ;;
           esac
         done < files.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,11 +73,14 @@ jobs:
           case $file in 
             slam-libraries/viam-cartographer/*)
               echo "run_carto=true" >> $GITHUB_OUTPUT
+              echo "yes carto"
               ;;
             slam-libraries/viam-orb-slam4/*)
               echo "run_orb=true" >> $GITHUB_OUTPUT
+              echo "yes orb"
               ;;
             *)
+              echo "yes both"
               echo "run_orb=true" >> $GITHUB_OUTPUT
               echo "run_carto=true" >> $GITHUB_OUTPUT
               ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,22 +58,23 @@ jobs:
     - name: Check modified files
       id: check_files
       run: |
+        git fetch origin main
         echo "Listing modified files..."
         git diff $(git merge-base --fork-point main)
         echo "Check paths of modified files..."
         git diff $(git merge-base --fork-point main) > files.txt
-        echo "::set-output name=run_carto::false"
-        echo "::set-output name=run_orb::false"
+        echo "run_carto=false" >> $GITHUB_OUTPUT
+        echo "run_orb=false" >> $GITHUB_OUTPUT
         while IFS= read -r file
         do
           echo $file
           if [[ $file != slam-libraries/viam-orb-slam3/* ]]; then
             echo "This modified file is not under 'viam-orb-slam3'"
-            echo "::set-output name=run_carto::true"
+            echo "run_carto=true" >> $GITHUB_OUTPUT
           fi
           if [[ $file != slam-libraries/viam-cartographer/* ]]; then
             echo "This modified file is not under 'viam-cartographer'"
-            echo "::set-output name=run_orb::true"
+            echo "run_orb=true" >> $GITHUB_OUTPUT
           fi
         done < files.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,15 +54,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-        fetch-depth: 2
 
     - name: Check modified files
       id: check_files
       run: |
         echo "Listing modified files..."
-        git diff --name-only HEAD^ HEAD
+        git diff --name-only `git merge-base --fork-point main`
         echo "Check paths of modified files..."
-        git diff --name-only HEAD^ HEAD &gt; files.txt
+        git diff --name-only `git merge-base --fork-point main` > files.txt
         echo "::set-output name=run_carto::false"
         echo "::set-output name=run_orb::false"
         while IFS= read -r file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,9 @@ jobs:
         git fetch origin main
         echo "Listing modified files..."
         echo $(git merge-base --fork-point origin/main)
-        git diff $(git merge-base --fork-point origin/main)
+        git diff --name-only $(git merge-base --fork-point origin/main)
         echo "Check paths of modified files..."
-        git diff $(git merge-base --fork-point origin/main) > files.txt
+        git diff --name-only $(git merge-base --fork-point origin/main) > files.txt
         echo "run_carto=false" >> $GITHUB_OUTPUT
         echo "run_orb=false" >> $GITHUB_OUTPUT
         while IFS= read -r file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: Check modified files
       id: check_files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,11 +58,10 @@ jobs:
     - name: Check modified files
       id: check_files
       run: |
-        git fetch origin main
         echo "Listing modified files..."
-        git diff --name-only origin/main...
+        git diff $(git merge-base --fork-point main)
         echo "Check paths of modified files..."
-        git diff --name-only origin/main... > files.txt
+        git diff $(git merge-base --fork-point main) > files.txt
         echo "::set-output name=run_carto::false"
         echo "::set-output name=run_orb::false"
         while IFS= read -r file
@@ -76,6 +75,7 @@ jobs:
             echo "This modified file is not under 'viam-cartographer'"
             echo "::set-output name=run_orb::true"
           fi
+        done < files.txt
 
   build_and_test_orb:
     name: Build and Test Orbslam

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,11 +70,11 @@ jobs:
         while IFS= read -r file
         do
           echo $file
-          if [[ $file != slam-libraries/viam-orb-slam3/* ]]; then
+          if [ $file != slam-libraries/viam-orb-slam3/* ]; then
             echo "This modified file is not under 'viam-orb-slam3'"
             echo "run_carto=true" >> $GITHUB_OUTPUT
           fi
-          if [[ $file != slam-libraries/viam-cartographer/* ]]; then
+          if [ $file != slam-libraries/viam-cartographer/* ]; then
             echo "This modified file is not under 'viam-cartographer'"
             echo "run_orb=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         git fetch origin main
         echo "Listing modified files..."
+        git merge-base --fork-point main
         git diff $(git merge-base --fork-point main)
         echo "Check paths of modified files..."
         git diff $(git merge-base --fork-point main) > files.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,15 +54,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-        fetch-depth: 0
 
     - name: Check modified files
       id: check_files
       run: |
         echo "Listing modified files..."
-        git diff --name-only `git merge-base --fork-point main`
+        git diff --name-only `git merge-base --fork-point refs/remotes/origin/main`
         echo "Check paths of modified files..."
-        git diff --name-only `git merge-base --fork-point main` > files.txt
+        git diff --name-only `git merge-base --fork-point refs/remotes/origin/main` > files.txt
         echo "::set-output name=run_carto::false"
         echo "::set-output name=run_orb::false"
         while IFS= read -r file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
       run: |
         git fetch origin main
         echo "Listing modified files..."
-        echo $(git merge-base --fork-point origin/main)
         git diff --name-only $(git merge-base --fork-point origin/main)
         echo "Check paths of modified files..."
         git diff --name-only $(git merge-base --fork-point origin/main) > files.txt
@@ -73,14 +72,11 @@ jobs:
           case $file in 
             slam-libraries/viam-cartographer/*)
               echo "run_carto=true" >> $GITHUB_OUTPUT
-              echo "yes carto"
               ;;
-            slam-libraries/viam-orb-slam4/*)
+            slam-libraries/viam-orb-slam3/*)
               echo "run_orb=true" >> $GITHUB_OUTPUT
-              echo "yes orb"
               ;;
             *)
-              echo "yes both"
               echo "run_orb=true" >> $GITHUB_OUTPUT
               echo "run_carto=true" >> $GITHUB_OUTPUT
               ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      REPO_READ_TOKEN:
-        required: true
       ARTIFACT_READ_ONLY_GCP_CREDENTIALS:
         required: true
 
@@ -109,10 +107,6 @@ jobs:
     timeout-minutes: 180
 
     steps:
-    - name: Configure git for private repos
-      run: |
-        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
-
     - name: Check out code in slam directory
       uses: actions/checkout@v3
       with:
@@ -185,10 +179,6 @@ jobs:
       with:
         submodules: recursive
         path: slam
-
-    - name: Configure git for private repos
-      run: |
-        sudo -u testbot bash -lc 'echo "machine github.com login viambot password ${{ secrets.REPO_READ_TOKEN }}" > ~/.netrc'
 
     - name: make setupcarto
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,10 @@ jobs:
       run: |
         git fetch origin main
         echo "Listing modified files..."
-        git merge-base --fork-point main
-        git diff $(git merge-base --fork-point main)
+        git merge-base --fork-point origin/main
+        git diff $(git merge-base --fork-point origin/main)
         echo "Check paths of modified files..."
-        git diff $(git merge-base --fork-point main) > files.txt
+        git diff $(git merge-base --fork-point origin/main) > files.txt
         echo "run_carto=false" >> $GITHUB_OUTPUT
         echo "run_orb=false" >> $GITHUB_OUTPUT
         while IFS= read -r file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
     - name: make buf
       timeout-minutes: 5
       run: |
+        chown -R testbot .
         sudo -u testbot bash -lc 'cd slam/slam-libraries && make buf'
 
     - name: make setuporb
@@ -186,4 +187,5 @@ jobs:
 
     - name: make buildcarto
       run: |
+        chown -R testbot .
         sudo -u testbot bash -lc 'cd slam/slam-libraries && make buildcarto'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
     - name: Check modified files
       id: check_files
       run: |
+        #!/bin/bash
         git fetch origin main
         echo "Listing modified files..."
         echo $(git merge-base --fork-point origin/main)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Check modified files
       id: check_files
       run: |
-        #!/bin/bash
         git fetch origin main
         echo "Listing modified files..."
         echo $(git merge-base --fork-point origin/main)
@@ -71,14 +70,15 @@ jobs:
         while IFS= read -r file
         do
           echo $file
-          if [ $file != slam-libraries/viam-orb-slam3/* ]; then
-            echo "This modified file is not under 'viam-orb-slam3'"
-            echo "run_carto=true" >> $GITHUB_OUTPUT
-          fi
-          if [ $file != slam-libraries/viam-cartographer/* ]; then
-            echo "This modified file is not under 'viam-cartographer'"
-            echo "run_orb=true" >> $GITHUB_OUTPUT
-          fi
+          case $file in 
+            slam-libraries/viam-cartographer/*)
+              echo "run_carto=true" >> $GITHUB_OUTPUT
+            slam-libraries/viam-orb-slam4/*)
+              echo "run_orb=true" >> $GITHUB_OUTPUT
+            *)
+              echo "run_orb=true" >> $GITHUB_OUTPUT
+              echo "run_carto=true" >> $GITHUB_OUTPUT
+          esac
         done < files.txt
 
   build_and_test_orb:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,9 @@ jobs:
       run: |
         git fetch origin main
         echo "Listing modified files..."
-        git diff --name-only `git merge-base --fork-point origin/main`
+        git diff --name-only origin/main...
         echo "Check paths of modified files..."
-        git diff --name-only `git merge-base --fork-point origin/main` > files.txt
+        git diff --name-only origin/main... > files.txt
         echo "::set-output name=run_carto::false"
         echo "::set-output name=run_orb::false"
         while IFS= read -r file

--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -53,4 +53,12 @@ appimage: buildorb
 	mv packaging/appimages/*.AppImage* packaging/appimages/deploy/
 	chmod 755 packaging/appimages/deploy/*.AppImage
 
+setupcarto:
+    cd viam-cartographer/scripts && ./setup_cartographer.sh
+
+buildcarto:
+    cd viam-cartographer/scripts && ./build_cartographer.sh && ./build_viam_cartographer.sh
+
+carto-all: setupcarto buildcarto
+
 include *.make

--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -54,10 +54,10 @@ appimage: buildorb
 	chmod 755 packaging/appimages/deploy/*.AppImage
 
 setupcarto:
-    cd viam-cartographer/scripts && ./setup_cartographer.sh
+	cd viam-cartographer/scripts && ./setup_cartographer.sh
 
 buildcarto:
-    cd viam-cartographer/scripts && ./build_cartographer.sh && ./build_viam_cartographer.sh
+	cd viam-cartographer/scripts && ./build_cartographer.sh && ./build_viam_cartographer.sh
 
 carto-all: setupcarto buildcarto
 

--- a/slam-libraries/viam-cartographer/README.md
+++ b/slam-libraries/viam-cartographer/README.md
@@ -49,20 +49,7 @@ brew install sphinx-doc
 
 ### Setup: Raspberry Pi OS Lite (64-bit)
 
-```bash
-sudo apt install cmake \
-ninja-build \
-libgmock-dev \
-libboost-iostreams-dev \
-liblua5.3-dev \
-libcairo2-dev \
-python3-sphinx \
-libabsl-dev \
-libceres-dev \
-libprotobuf-dev \
-protobuf-compiler \
-libpcl-dev
-```
+Run: `./scripts/setup_cartographer.sh`
  
  ### Building cartographer
 **Build cartographer**
@@ -72,6 +59,7 @@ Run: `./scripts/build_cartographer.sh`
 Installation & building tested on:
 - [X] Raspberry Pi OS Lite (64-bit)
 - [X] 2.4 GHz 8-Core Intel Core i9; macOS Monterey
+- [X] linux/amd64
 - [ ] M1
 
 This needs to be built only once.
@@ -83,6 +71,7 @@ Run: `./scripts/build_viam_cartographer.sh`
 Installation & building tested on:
 - [X] Raspberry Pi OS Lite (64-bit)
 - [X] 2.4 GHz 8-Core Intel Core i9; macOS Monterey
+- [X] linux/amd64
 - [ ] M1
 
 This is run frequently, as this is where we're building our code.

--- a/slam-libraries/viam-cartographer/scripts/setup_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/setup_cartographer.sh
@@ -1,0 +1,3 @@
+echo "Installing cartographer external dependencies"
+sudo apt update
+sudo apt install cmake ninja-build libgmock-dev libboost-iostreams-dev liblua5.3-dev libcairo2-dev python3-sphinx libabsl-dev libceres-dev libprotobuf-dev protobuf-compiler libpcl-dev

--- a/slam-libraries/viam-cartographer/scripts/setup_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/setup_cartographer.sh
@@ -1,3 +1,3 @@
 echo "Installing cartographer external dependencies"
 sudo apt update
-sudo apt install cmake ninja-build libgmock-dev libboost-iostreams-dev liblua5.3-dev libcairo2-dev python3-sphinx libabsl-dev libceres-dev libprotobuf-dev protobuf-compiler libpcl-dev
+sudo apt install -y cmake ninja-build libgmock-dev libboost-iostreams-dev liblua5.3-dev libcairo2-dev python3-sphinx libabsl-dev libceres-dev libprotobuf-dev protobuf-compiler libpcl-dev

--- a/slam-libraries/viam-cartographer/src/slam_service/config.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.h
@@ -4,6 +4,7 @@
 #define CONFIG_H_
 
 #include <atomic>
+#include <string>
 
 namespace viam {
 


### PR DESCRIPTION
This ensures we don't run orbslam tests when only cartographer files have changed and vice versa. After this change, we can make the "Format", "Build and Test Orbslam", and "Build and Test Cartographer" jobs required for merge. If one of these doesn't run (because the code didn't change), that shouldn't prevent merge.