### PR TITLE
[DATA-567] Support running cartographer through rdk

### DIFF
--- a/slam-libraries/viam-cartographer/CMakeLists.txt
+++ b/slam-libraries/viam-cartographer/CMakeLists.txt
@@ -92,7 +92,7 @@ configure_file(
 
 message("PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR: ${PROJECT_SOURCE_DIR}, ${PROJECT_BINARY_DIR}")
 
-google_binary(main
+google_binary(carto_grpc_server
   SRCS
     src/main.cc
 )
@@ -114,8 +114,8 @@ google_binary(main_old
 # This task is postponed until I start working on these two tickets (the last two tickets to be tackled):
 # https://viam.atlassian.net/browse/DATA-123
 # https://viam.atlassian.net/browse/DATA-124
-target_link_libraries(main PUBLIC "/usr/local/lib/libcartographer.a")
-target_include_directories(main SYSTEM PUBLIC "/usr/local/include/cartographer")
+target_link_libraries(carto_grpc_server PUBLIC "/usr/local/lib/libcartographer.a")
+target_include_directories(carto_grpc_server SYSTEM PUBLIC "/usr/local/include/cartographer")
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   "${CERES_INCLUDE_DIRS}")

--- a/slam-libraries/viam-cartographer/scripts/run_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/run_cartographer.sh
@@ -32,7 +32,7 @@ cd output
 rm -rf ${OUTPUT_DIRECTORY}
 mkdir ${OUTPUT_DIRECTORY}
 
-../build/main  \
+../build/carto_grpc_server  \
     -data_dir=${DATA_DIR}  \
     -config_param="{mode=2D,}"  \
     -port=8080  \

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -14,6 +14,9 @@ void exit_loop_handler(int s) {
 }
 
 int main(int argc, char** argv) {
+    // glog only supports logging to files and stderr, not stdout.
+    FLAGS_alsologtostderr = 1;
+    google::InitGoogleLogging(argv[0]);
     struct sigaction sigIntHandler;
 
     sigIntHandler.sa_handler = exit_loop_handler;

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -21,7 +21,7 @@ DEFINE_int64(
     "Frequency at which we want to print map pictures while cartographer "
     "is running.");
 DEFINE_string(input_file_pattern, "", "Input file pattern");
-DEFINE_string(aix_auto_update, "", "Automatically updates the app image");
+DEFINE_bool(aix_auto_update, false, "Automatically updates the app image");
 
 // Parses and validates the command line arguments. Sets the log level. Throws
 // an exception if the arguments are malformed.

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -27,7 +27,7 @@ DEFINE_string(aix_auto_update, "", "Automatically updates the app image");
 // an exception if the arguments are malformed.
 int ParseAndValidateConfigParams(int argc, char** argv) {
     // glog only supports logging to files and stderr, not stdout.
-    FLAGS_alsologtostderr= 1;
+    FLAGS_alsologtostderr = 1;
     google::InitGoogleLogging(argv[0]);
     google::ParseCommandLineFlags(&argc, &argv, true);
 

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -21,10 +21,14 @@ DEFINE_int64(
     "Frequency at which we want to print map pictures while cartographer "
     "is running.");
 DEFINE_string(input_file_pattern, "", "Input file pattern");
+DEFINE_string(aix_auto_update, "", "Automatically updates the app image");
 
 // Parses and validates the command line arguments. Sets the log level. Throws
 // an exception if the arguments are malformed.
 int ParseAndValidateConfigParams(int argc, char** argv) {
+    // glog only supports logging to files and stderr, not stdout.
+    FLAGS_alsologtostderr= 1;
+    google::InitGoogleLogging(argv[0]);
     google::ParseCommandLineFlags(&argc, &argv, true);
 
     if (FLAGS_data_dir.empty()) {
@@ -36,9 +40,6 @@ int ParseAndValidateConfigParams(int argc, char** argv) {
     } else if (FLAGS_port.empty()) {
         LOG(ERROR) << "-port is missing.\n";
         return EXIT_FAILURE;
-    } else if (FLAGS_sensors.empty()) {
-        LOG(ERROR) << "-sensors is missing.\n";
-        // return EXIT_FAILURE;
     }
     LOG(INFO) << "data_dir: " << FLAGS_data_dir << "\n";
     LOG(INFO) << "config_param: " << FLAGS_config_param << "\n";

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -26,9 +26,6 @@ DEFINE_bool(aix_auto_update, false, "Automatically updates the app image");
 // Parses and validates the command line arguments. Sets the log level. Throws
 // an exception if the arguments are malformed.
 int ParseAndValidateConfigParams(int argc, char** argv) {
-    // glog only supports logging to files and stderr, not stdout.
-    FLAGS_alsologtostderr = 1;
-    google::InitGoogleLogging(argv[0]);
     google::ParseCommandLineFlags(&argc, &argv, true);
 
     if (FLAGS_data_dir.empty()) {


### PR DESCRIPTION
Together with https://github.com/viamrobotics/rdk/pull/1507, this lets us run cartographer through rdk.