### PR TITLE
[DATA-609] Add live ingestion loop

### DIFF
--- a/slam-libraries/viam-cartographer/src/io/read_PCD_file.cc
+++ b/slam-libraries/viam-cartographer/src/io/read_PCD_file.cc
@@ -85,9 +85,13 @@ int RemoveFile(std::string file_path) {
 
 // Converts UTC time string to a double value.
 double ReadTimeFromFilename(std::string filename) {
-    // TODO: change time format "%Y-%m-%dT%H:%M:%SZ"
-    // https://viam.atlassian.net/browse/DATA-638
-    std::string time_format = "%Y-%m-%dT%H_%M_%S";
+    std::string time_format = "%Y-%m-%dT%H:%M:%SZ";
+
+    // TODO DATA-638 remove this check
+    if (filename.find("_") != std::string::npos) {
+        time_format = "%Y-%m-%dT%H_%M_%S";
+    }
+
     std::string::size_type sz;
     // Create a stream which we will use to parse the string
     std::istringstream ss(filename);

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -44,9 +44,9 @@ int main(int argc, char** argv) {
     std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
     LOG(INFO) << "Server listening on " << *selected_port << "\n";
 
-    LOG(INFO) << "Start mapping: offline mode\n";
-    slamService.ProcessDataOffline();
-    LOG(INFO) << "Done mapping: offline mode\n";
+    LOG(INFO) << "Start mapping";
+    slamService.ProcessData();
+    LOG(INFO) << "Done mapping";
 
     while (viam::b_continue_session) {
         LOG(INFO) << "Cartographer is running\n";

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -76,22 +76,14 @@ void MapBuilder::SetStartTime(std::string initial_filename) {
 }
 
 cartographer::sensor::TimedPointCloudData MapBuilder::GetDataFromFile(
-    std::string data_directory, int i) {
+    std::string file) {
     cartographer::sensor::TimedPointCloudData point_cloud;
-
-    std::vector<std::string> files =
-        viam::io::ListFilesInDirectory(data_directory);
-
-    if (files.size() == 0) {
-        LOG(INFO) << "No files found in data directory\n";
-        return point_cloud;
-    }
 
     if (start_time == -1) {
         throw std::runtime_error("start_time has not been initialized");
     }
     point_cloud =
-        viam::io::TimedPointCloudDataFromPCDBuilder(files[i], start_time);
+        viam::io::TimedPointCloudDataFromPCDBuilder(file, start_time);
 
     LOG(INFO) << "----------PCD-------";
     LOG(INFO) << "Time: " << point_cloud.time;

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -82,8 +82,7 @@ cartographer::sensor::TimedPointCloudData MapBuilder::GetDataFromFile(
     if (start_time == -1) {
         throw std::runtime_error("start_time has not been initialized");
     }
-    point_cloud =
-        viam::io::TimedPointCloudDataFromPCDBuilder(file, start_time);
+    point_cloud = viam::io::TimedPointCloudDataFromPCDBuilder(file, start_time);
 
     LOG(INFO) << "----------PCD-------";
     LOG(INFO) << "Time: " << point_cloud.time;

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -31,8 +31,7 @@ class MapBuilder {
     GetLocalSlamResultCallback();
 
     void SetStartTime(std::string initial_filename);
-    cartographer::sensor::TimedPointCloudData GetDataFromFile(
-        std::string data_directory, int i);
+    cartographer::sensor::TimedPointCloudData GetDataFromFile(std::string file);
 
     std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder_;
     cartographer::mapping::proto::MapBuilderOptions map_builder_options_;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -257,12 +257,14 @@ std::string SLAMServiceImpl::GetNextDataFile() {
         return to_return;
     }
     // online processing
-    while(b_continue_session) {
-        const auto file_list_online = viam::io::ListFilesInDirectory(path_to_data);
+    while (b_continue_session) {
+        const auto file_list_online =
+            viam::io::ListFilesInDirectory(path_to_data);
         if (file_list_online.size() > 1) {
             // Get the second-most-recent file, since the most-recent file may
             // still be being written.
-            const auto to_return = file_list_online[file_list_online.size()-2];
+            const auto to_return =
+                file_list_online[file_list_online.size() - 2];
             if (to_return.compare(current_file_online) != 0) {
                 current_file_online = to_return;
                 return to_return;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -257,8 +257,9 @@ std::string SLAMServiceImpl::GetNextDataFileOffline() {
 }
 
 std::string SLAMServiceImpl::GetNextDataFileOnline() {
-    while(b_continue_session) {
-        const auto file_list_online = viam::io::ListFilesInDirectory(path_to_data);
+    while (b_continue_session) {
+        const auto file_list_online =
+            viam::io::ListFilesInDirectory(path_to_data);
         if (file_list_online.size() > 1) {
             // Get the second-most-recent file, since the most-recent file may
             // still be being written.

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -55,11 +55,19 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // received.
     void ProcessData();
 
-    // In offline mode, returns the next data file in the directory. In online
-    // mode, returns the most recently generated data that has not been been
-    // processed. Returns an empty string if done processing files in offline
-    // mode, or if stop has been signaled.
+    // GetNextDataFile returns the next data file to be processed, determined
+    // by whether cartographer is running in offline or online mode.
     std::string GetNextDataFile();
+
+    // GetNextDataFileOffline returns the next data file in the directory.
+    // Returns an empty string if done processing files or if stop has been
+    // signaled.
+    std::string GetNextDataFileOffline();
+
+    // GetNextDataFileOnline returns the most recently generated data that has
+    // not been been processed, blocking if no new file is found. Returns an
+    // empty string if stop has been signaled.
+    std::string GetNextDataFileOnline();
 
     // CreateMap creates a map from scratch.
     void CreateMap();
@@ -125,7 +133,6 @@ class SLAMServiceImpl final : public SLAMService::Service {
     double rotation_weight = 1.0;
 
    private:
-    int picture_print_interval = 50;
     const std::string configuration_mapping_basename = "mapping_new_map.lua";
     const std::string configuration_localization_basename =
         "locating_in_map.lua";

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -49,15 +49,19 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 
-    // ProcessDataOffline processes all existing data in offline mode until
-    // there is no more data left to go through.
-    void ProcessDataOffline();
+    // ProcessData process the data in the data directory. In offline mode,
+    // all data in the directory is processed. In online mode, the most
+    // recently generated data is processed until a shutdown signal is
+    // received.
+    void ProcessData();
 
-    // Placeholder function with full "offline mode" functionality that will
-    // be picked apart with future tickets into separate functions (GetMap,
-    // GetPosition, ProcessDataOnline, ProcessDataOffline). Gives an overview
-    // over how mapping + png map image creation + pbstream map saving is
-    // started & executed.
+    // In offline mode, returns the next data file in the directory. In online
+    // mode, returns the most recently generated data that has not been been
+    // processed. Returns an empty string if done processing files in offline
+    // mode, or if stop has been signaled.
+    std::string GetNextDataFile();
+
+    // CreateMap creates a map from scratch.
     void CreateMap();
 
     // GetActionMode returns the slam action mode from the provided
@@ -121,12 +125,14 @@ class SLAMServiceImpl final : public SLAMService::Service {
     double rotation_weight = 1.0;
 
    private:
-    int starting_scan_number = 0;
     int picture_print_interval = 50;
     const std::string configuration_mapping_basename = "mapping_new_map.lua";
     const std::string configuration_localization_basename =
         "locating_in_map.lua";
     const std::string configuration_update_basename = "updating_a_map.lua";
+    std::vector<std::string> file_list_offline;
+    size_t current_file_offline = 0;
+    std::string current_file_online;
 
     std::mutex map_builder_mutex;
     mapping::MapBuilder map_builder;


### PR DESCRIPTION
https://viam.atlassian.net/browse/DATA-609

This took less time than I thought, thanks to the work that had already been done! I tested both online and offline processing using data generated through rdk. I tested on a raspberry pi with the rplidar server running. I used this config for online (modified for offline):
```
{
  "services": [{
		  "name": "testcarto",
		  "type": "slam",
		  "attributes": 
        {
          "algorithm": "cartographer",
          "sensors": ["rplidar"],
          "config_params": {
          "mode": "2d",
          "v": "1"
        },
      "data_dir": "$HOME/carto-data"
    }}],
  "network": {
    "bind_address": "0.0.0.0:8080"
  },
  "remotes": [{
    "address": "localhost:4444",
    "name": "lidar",
    "prefix": false
  }]
}
```
Cartographer was able to process the data and respond to `GetMap` requests.