### PR TITLE
HotFix: Add bufinstall to make carto-all

### DIFF
--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -68,6 +68,6 @@ buildcarto:
 testcarto:
 	cd viam-cartographer/scripts && ./test_cartographer.sh
 
-carto-all: buf setupcarto buildcarto testcarto
+carto-all: bufinstall buf setupcarto buildcarto testcarto
 
 include *.make


### PR DESCRIPTION
This already exists for orbslam, needs to be added to carto-all