### PR TITLE
[DATA-733] Throw error if no map is found

### DIFF
--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -123,6 +123,10 @@ void SLAMServiceImpl::DetermineActionMode() {
             return;
         }
     }
+    if (map_rate_sec.count() == 0) {
+        throw std::runtime_error(
+            "In localization mode but couldn't find a map to localize on");
+    }
     LOG(INFO) << "Running in mapping mode";
     action_mode = SLAMServiceActionMode::MAPPING;
 }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -125,7 +125,8 @@ void SLAMServiceImpl::DetermineActionMode() {
     }
     if (map_rate_sec.count() == 0) {
         throw std::runtime_error(
-            "In localization mode but couldn't find a map to localize on");
+            "set to localization mode (map_rate_sec = 0) but couldn't find "
+            "apriori map to localize on");
     }
     LOG(INFO) << "Running in mapping mode";
     action_mode = SLAMServiceActionMode::MAPPING;


### PR DESCRIPTION
https://viam.atlassian.net/browse/DATA-733

**Situation:** The user chooses `map_rate_sec = 0` - which technically means running SLAM in localization action mode - but no map is found in the `data/map` folder.

**Previous behavior:** Run SLAM in mapping mode (since no map is found) but don't save maps (since `map_rate_sec == 0`).

**New behavior:** Throw an error, since we assume the user wants to run SLAM in localization mode but we can't find a map to localize on.

**Tested on:**
* 2.4 GHz 8-Core Intel Core i9; macOS Monterey