### PR TITLE
[DATA-117] Read optimize_on_start parameter from config_params

### DIFF
--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -64,6 +64,7 @@ void MapBuilder::LoadMapFromFile(std::string map_filename,
         map_builder_->LoadStateFromFile(map_filename, load_frozen_trajectory);
 
     if (optimize_on_start) {
+        LOG(INFO) << "Optimizing map on start, this may take a few minutes";
         map_builder_->pose_graph()->RunFinalOptimization();
     }
     for (auto&& trajectory_ids_pair : trajectory_ids_map)

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -58,11 +58,12 @@ void MapBuilder::BuildMapBuilder() {
 }
 
 void MapBuilder::LoadMapFromFile(std::string map_filename,
-                                 bool load_frozen_trajectory, bool optimize) {
+                                 bool load_frozen_trajectory,
+                                 bool optimize_on_start) {
     std::map<int, int> trajectory_ids_map =
         map_builder_->LoadStateFromFile(map_filename, load_frozen_trajectory);
 
-    if (optimize) {
+    if (optimize_on_start) {
         map_builder_->pose_graph()->RunFinalOptimization();
     }
     for (auto&& trajectory_ids_pair : trajectory_ids_map)

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -35,7 +35,7 @@ class MapBuilder {
     // in updating or localizing mode, depending on the load_frozen_trajectory
     // value.
     void LoadMapFromFile(std::string map_filename, bool load_frozen_trajectory,
-                         bool optimize);
+                         bool optimize_on_start);
 
     // SaveMapToFile saves the current map_builder_ state to a pbstream file at
     // the provided path.

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -45,12 +45,6 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     if (!v.empty()) {
         FLAGS_v = std::stoi(v);
     }
-    const auto optimize_on_start =
-        ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
-    if (optimize_on_start == "true") {
-        slamService.optimize_on_start = true;
-        LOG(INFO) << "Optimizing map on start";
-    }
 
     if (FLAGS_data_dir.empty()) {
         throw std::runtime_error("-data_dir is missing");
@@ -88,6 +82,13 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     boost::algorithm::to_lower(slamService.slam_mode);
     if (slamService.slam_mode != "2d" && slamService.slam_mode != "3d") {
         throw std::runtime_error("Invalid slam_mode=" + slamService.slam_mode);
+    }
+
+    const auto optimize_on_start =
+        ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
+    if (optimize_on_start == "true") {
+        slamService.optimize_on_start = true;
+        LOG(INFO) << "Optimizing map on start, this may take a few minutes";
     }
 
     std::vector<std::string> carto_params = {"optimize_every_n_nodes",

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -46,7 +46,7 @@ void ParseAndValidateConfigParams(int argc, char** argv,
         FLAGS_v = std::stoi(v);
     }
     const auto optimize_on_start = ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
-    if (!optimize_on_start.empty()) {
+    if (optimize_on_start == "true") {
         slamService.optimize_on_start = true;
         LOG(INFO) << "Optimizing map on start";
     }

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -45,6 +45,11 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     if (!v.empty()) {
         FLAGS_v = std::stoi(v);
     }
+    const auto optimize_on_start = ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
+    if (!optimize_on_start.empty()) {
+        slamService.optimize_on_start = true;
+        LOG(INFO) << "Optimizing map on start";
+    }
 
     if (FLAGS_data_dir.empty()) {
         throw std::runtime_error("-data_dir is missing");
@@ -54,7 +59,7 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     }
     if (FLAGS_sensors.empty()) {
         LOG(INFO) << "No camera given -> running in offline mode";
-        slamService.offlineFlag = true;
+        slamService.offline_flag = true;
     }
 
     LOG(INFO) << "data_dir: " << FLAGS_data_dir << "\n";

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -88,7 +88,6 @@ void ParseAndValidateConfigParams(int argc, char** argv,
         ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
     if (optimize_on_start == "true") {
         slamService.optimize_on_start = true;
-        LOG(INFO) << "Optimizing map on start, this may take a few minutes";
     }
 
     std::vector<std::string> carto_params = {"optimize_every_n_nodes",

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -45,7 +45,8 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     if (!v.empty()) {
         FLAGS_v = std::stoi(v);
     }
-    const auto optimize_on_start = ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
+    const auto optimize_on_start =
+        ConfigParamParser(FLAGS_config_param, "optimize_on_start=");
     if (optimize_on_start == "true") {
         slamService.optimize_on_start = true;
         LOG(INFO) << "Optimizing map on start";

--- a/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
@@ -217,7 +217,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_valid_config) {
     BOOST_TEST(slamService.map_rate_sec.count() ==
                std::chrono::seconds(60).count());
     BOOST_TEST(slamService.camera_name == "lidar");
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.offline_flag == false);
+    BOOST_TEST(slamService.optimize_on_start == false);
     delete argv;
 }
 
@@ -226,6 +227,7 @@ BOOST_AUTO_TEST_CASE(
     ResetFlagsForTesting();
     std::string config_param =
         "{mode=2d,"
+        "optimize_on_start=true,"
         "optimize_every_n_nodes=9000,num_range_data=9001,"
         "missing_data_ray_length=9002.2,max_range=9003.3,"
         "min_range=9004.4,max_submaps_to_keep=9005,"
@@ -266,7 +268,8 @@ BOOST_AUTO_TEST_CASE(
     BOOST_TEST(slamService.map_rate_sec.count() ==
                std::chrono::seconds(60).count());
     BOOST_TEST(slamService.camera_name == "lidar");
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.offline_flag == false);
+    BOOST_TEST(slamService.optimize_on_start == true);
     delete argv;
 }
 
@@ -327,7 +330,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_valid_config_no_camera) {
     SLAMServiceImpl slamService;
     ParseAndValidateConfigParams(argc, argv, slamService);
     BOOST_TEST(slamService.camera_name == "");
-    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.offline_flag == true);
     delete argv;
 }
 

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -353,10 +353,6 @@ void SLAMServiceImpl::RunSLAM() {
             throw std::runtime_error(
                 "cannot find maps but they should be present");
         }
-        // TODO: The optimize flag will become a flag that can be set by the
-        // user. Will be implemented here:
-        // https://viam.atlassian.net/browse/DATA-117
-        bool optimize = true;
         // load_frozen_trajectory has to be true for LOCALIZING action mode,
         // and false for UPDATING action mode.
         bool load_frozen_trajectory =
@@ -365,7 +361,7 @@ void SLAMServiceImpl::RunSLAM() {
             // Load apriori map
             std::lock_guard<std::mutex> lk(map_builder_mutex);
             map_builder.LoadMapFromFile(latest_map_filename,
-                                        load_frozen_trajectory, optimize);
+                                        load_frozen_trajectory, optimize_on_start);
         }
         data_start_time =
             viam::io::ReadTimeFromFilename(latest_map_filename.substr(
@@ -428,7 +424,7 @@ std::string SLAMServiceImpl::GetNextDataFileOnline() {
 }
 
 std::string SLAMServiceImpl::GetNextDataFile() {
-    if (offlineFlag) {
+    if (offline_flag) {
         return GetNextDataFileOffline();
     }
     return GetNextDataFileOnline();
@@ -460,7 +456,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
             std::chrono::duration<double, std::milli> time_elapsed_msec =
                 std::chrono::high_resolution_clock::now() - start;
             if ((time_elapsed_msec >= map_rate_sec) ||
-                (offlineFlag && finished_processing_offline)) {
+                (offline_flag && finished_processing_offline)) {
                 break;
             }
             if (map_rate_sec - time_elapsed_msec >=
@@ -475,7 +471,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
         const std::string filename_with_timestamp =
             viam::io::MakeFilenameWithTimestamp(path_to_map);
 
-        if (offlineFlag && finished_processing_offline) {
+        if (offline_flag && finished_processing_offline) {
             {
                 std::lock_guard<std::mutex> lk(map_builder_mutex);
                 map_builder.SaveMapToFile(true, filename_with_timestamp);
@@ -569,7 +565,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
         std::lock_guard<std::mutex> lk(map_builder_mutex);
         map_builder.map_builder_->FinishTrajectory(trajectory_id);
     }
-    if (offlineFlag) {
+    if (offline_flag) {
         {
             std::lock_guard<std::mutex> lk(map_builder_mutex);
             LOG(INFO)

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -360,8 +360,8 @@ void SLAMServiceImpl::RunSLAM() {
         {
             // Load apriori map
             std::lock_guard<std::mutex> lk(map_builder_mutex);
-            map_builder.LoadMapFromFile(latest_map_filename,
-                                        load_frozen_trajectory, optimize_on_start);
+            map_builder.LoadMapFromFile(
+                latest_map_filename, load_frozen_trajectory, optimize_on_start);
         }
         data_start_time =
             viam::io::ReadTimeFromFilename(latest_map_filename.substr(

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -126,7 +126,8 @@ class SLAMServiceImpl final : public SLAMService::Service {
     std::chrono::milliseconds data_rate_ms;
     std::chrono::seconds map_rate_sec;
     std::string slam_mode;
-    std::atomic<bool> offlineFlag{false};
+    std::atomic<bool> optimize_on_start{false};
+    std::atomic<bool> offline_flag{false};
 
     // -- Cartographer specific config params:
     // MAP_BUILDER.pose_graph


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/DATA-117

Done:
* Read optimize_on_start parameter from config parameters and use that to decide whether or not an uploaded map should be optimized before using it
* Rename: `offlineFlag` --> `offline_flag` for consistency