### PR TITLE
[RSDK-1044] Adjust log levels

### DIFF
--- a/slam-libraries/viam-cartographer/src/io/file_handler.cc
+++ b/slam-libraries/viam-cartographer/src/io/file_handler.cc
@@ -49,7 +49,7 @@ cartographer::sensor::TimedPointCloudData TimedPointCloudDataFromPCDBuilder(
     double time_delta = current_time - start_time;
 
     VLOG(1) << "Accessing file " << file_path << " ... ";
-    VLOG(1) << "Loaded " << cloud->width * cloud->height << " data points \n";
+    VLOG(1) << "Loaded " << cloud->width * cloud->height << " data points";
 
     for (size_t i = 0; i < cloud->points.size(); ++i) {
         cartographer::sensor::TimedRangefinderPoint timed_rangefinder_point;

--- a/slam-libraries/viam-cartographer/src/io/file_handler.cc
+++ b/slam-libraries/viam-cartographer/src/io/file_handler.cc
@@ -48,8 +48,8 @@ cartographer::sensor::TimedPointCloudData TimedPointCloudDataFromPCDBuilder(
         file_path.find(".pcd")));
     double time_delta = current_time - start_time;
 
-    LOG(INFO) << "Accessing file " << file_path << " ... ";
-    LOG(INFO) << "Loaded " << cloud->width * cloud->height << " data points \n";
+    VLOG(1) << "Accessing file " << file_path << " ... ";
+    VLOG(1) << "Loaded " << cloud->width * cloud->height << " data points \n";
 
     for (size_t i = 0; i < cloud->points.size(); ++i) {
         cartographer::sensor::TimedRangefinderPoint timed_rangefinder_point;
@@ -115,7 +115,7 @@ double ReadTimeFromTimestamp(std::string timestamp) {
         try {
             sub_sec = (double)std::stof(timestamp.substr(sub_sec_index), &sz);
         } catch (std::exception& e) {
-            LOG(ERROR) << e.what();
+            LOG(FATAL) << e.what();
             throw std::runtime_error(
                 "could not extract sub seconds from timestamp: " + timestamp);
         }

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
 
     // This log line is needed by rdk to get the port.
-    LOG(INFO) << "Server listening on " << *selected_port << "\n";
+    VLOG(0) << "Server listening on " << *selected_port << "\n";
 
     slamService.RunSLAM();
 

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -11,7 +11,7 @@
 #include "slam_service/slam_service.h"
 
 void exit_loop_handler(int s) {
-    LOG(INFO) << "Finishing session.\n";
+    LOG(INFO) << "Finishing session.";
     viam::b_continue_session = false;
 }
 

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -17,7 +17,7 @@ void exit_loop_handler(int s) {
 
 int main(int argc, char** argv) {
     // glog only supports logging to files and stderr, not stdout.
-    FLAGS_alsologtostderr = 1;
+    FLAGS_logtostderr = 1;
     google::InitGoogleLogging(argv[0]);
     struct sigaction sigIntHandler;
 

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
 
     // This log line is needed by rdk to get the port.
-    VLOG(0) << "Server listening on " << *selected_port << "\n";
+    LOG(INFO) << "Server listening on " << *selected_port << "\n";
 
     slamService.RunSLAM();
 

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -67,7 +67,7 @@ void MapBuilder::LoadMapFromFile(std::string map_filename,
         map_builder_->pose_graph()->RunFinalOptimization();
     }
     for (auto&& trajectory_ids_pair : trajectory_ids_map)
-        LOG(INFO) << "Trajectory ids mapping from apriori map: "
+        VLOG(1) << "Trajectory ids mapping from apriori map: "
                   << trajectory_ids_pair.first << " "
                   << trajectory_ids_pair.second;
 }
@@ -77,7 +77,7 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
     bool ok = map_builder_->SerializeStateToFile(include_unfinished_submaps,
                                                  filename_with_timestamp);
     if (!ok) {
-        LOG(WARNING) << "Saving the map to pbstream failed.";
+        LOG(ERROR) << "Saving the map to pbstream failed.";
     }
 }
 

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -68,8 +68,8 @@ void MapBuilder::LoadMapFromFile(std::string map_filename,
     }
     for (auto&& trajectory_ids_pair : trajectory_ids_map)
         VLOG(1) << "Trajectory ids mapping from apriori map: "
-                  << trajectory_ids_pair.first << " "
-                  << trajectory_ids_pair.second;
+                << trajectory_ids_pair.first << " "
+                << trajectory_ids_pair.second;
 }
 
 void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -45,8 +45,6 @@ void ParseAndValidateConfigParams(int argc, char** argv,
         ConfigParamParser(FLAGS_config_param, "minloglevel=");
     if (!minloglevel.empty()) {
         FLAGS_minloglevel = std::stoi(minloglevel);
-    } else {
-        FLAGS_minloglevel = 1;
     }
     const auto v = ConfigParamParser(FLAGS_config_param, "v=");
     if (!v.empty()) {

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -78,7 +78,7 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     auto relativePathToLuas = programLocation.parent_path().parent_path();
     relativePathToLuas.append("share/cartographer/lua_files");
     if (exists(relativePathToLuas)) {
-        LOG(INFO) << "Using lua files from relative path";
+        VLOG(1) << "Using lua files from relative path";
         slamService.configuration_directory = relativePathToLuas.string();
     } else {
         LOG(ERROR) << "No lua files found, looked in " << relativePathToLuas;

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -45,6 +45,8 @@ void ParseAndValidateConfigParams(int argc, char** argv,
         ConfigParamParser(FLAGS_config_param, "minloglevel=");
     if (!minloglevel.empty()) {
         FLAGS_minloglevel = std::stoi(minloglevel);
+    } else {
+        FLAGS_minloglevel = 1;
     }
     const auto v = ConfigParamParser(FLAGS_config_param, "v=");
     if (!v.empty()) {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -147,7 +147,7 @@ std::atomic<bool> b_continue_session{true};
     try {
         common::v1::PointCloudObject *pco = response->mutable_point_cloud();
         if (!pointcloud_has_points) {
-            LOG(FATAL) << "map pointcloud does not have points yet";
+            LOG(ERROR) << "map pointcloud does not have points yet";
             return grpc::Status(grpc::StatusCode::UNAVAILABLE,
                                 "map pointcloud does not have points yet");
         }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -439,7 +439,7 @@ std::string SLAMServiceImpl::GetNextDataFileOffline() {
     }
     if (current_file_offline == file_list_offline.size()) {
         // This log line is needed by rdk integration tests.
-        LOG(INFO) << "Finished processing offline data";
+        VLOG(1) << "Finished processing offline data";
         return "";
     }
     const auto to_return = file_list_offline[current_file_offline];

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -147,7 +147,7 @@ std::atomic<bool> b_continue_session{true};
     try {
         common::v1::PointCloudObject *pco = response->mutable_point_cloud();
         if (!pointcloud_has_points) {
-            LOG(ERROR) << "map pointcloud does not have points yet";
+            LOG(FATAL) << "map pointcloud does not have points yet";
             return grpc::Status(grpc::StatusCode::UNAVAILABLE,
                                 "map pointcloud does not have points yet");
         }
@@ -538,7 +538,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
         // Set TrajectoryBuilder
         trajectory_id = map_builder.SetTrajectoryBuilder(&trajectory_builder,
                                                          {kRangeSensorId});
-        LOG(INFO) << "Using trajectory ID: " << trajectory_id;
+        VLOG(1) << "Using trajectory ID: " << trajectory_id;
     }
 
     LOG(INFO) << "Beginning to add data...";
@@ -622,7 +622,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
 
             std::lock_guard<std::mutex> lk(map_builder_mutex);
             LOG(INFO)
-                << "Starting to optimize final map. Can take a little while...";
+                << "Starting to optimize final map. This can take a little while...";
             map_builder.map_builder_->pose_graph()->RunFinalOptimization();
 
             auto local_poses = map_builder.GetLocalSlamResultPoses();
@@ -640,7 +640,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
         LOG(INFO) << "Finished optimizing final map";
 
         while (viam::b_continue_session) {
-            LOG(INFO) << "Standing by to continue serving requests\n";
+            VLOG(1) << "Standing by to continue serving requests\n";
             std::this_thread::sleep_for(std::chrono::microseconds(
                 viam::checkForShutdownIntervalMicroseconds));
         }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -439,7 +439,7 @@ std::string SLAMServiceImpl::GetNextDataFileOffline() {
     }
     if (current_file_offline == file_list_offline.size()) {
         // This log line is needed by rdk integration tests.
-        VLOG(1) << "Finished processing offline data";
+        LOG(INFO) << "Finished processing offline data";
         return "";
     }
     const auto to_return = file_list_offline[current_file_offline];
@@ -637,7 +637,8 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
             latest_global_pose = tmp_global_pose;
         }
         finished_processing_offline = true;
-        LOG(INFO) << "Finished optimizing final map";
+        // This log line is needed by rdk integration tests.
+        VLOG(1) << "Finished optimizing final map";
 
         while (viam::b_continue_session) {
             VLOG(1) << "Standing by to continue serving requests";

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -621,8 +621,8 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
             optimization_lock.lock();
 
             std::lock_guard<std::mutex> lk(map_builder_mutex);
-            LOG(INFO)
-                << "Starting to optimize final map. This can take a little while...";
+            LOG(INFO) << "Starting to optimize final map. This can take a "
+                         "little while...";
             map_builder.map_builder_->pose_graph()->RunFinalOptimization();
 
             auto local_poses = map_builder.GetLocalSlamResultPoses();

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -640,7 +640,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
         LOG(INFO) << "Finished optimizing final map";
 
         while (viam::b_continue_session) {
-            VLOG(1) << "Standing by to continue serving requests\n";
+            VLOG(1) << "Standing by to continue serving requests";
             std::this_thread::sleep_for(std::chrono::microseconds(
                 viam::checkForShutdownIntervalMicroseconds));
         }

--- a/slam-libraries/viam-cartographer/src/utils/slam_service_helpers.cc
+++ b/slam-libraries/viam-cartographer/src/utils/slam_service_helpers.cc
@@ -36,9 +36,11 @@ ActionMode DetermineActionMode(std::string path_to_map,
             // There is an apriori map present, so we're running either in
             // updating or localization mode.
             if (map_rate_sec.count() == 0) {
+                // This log line is needed by rdk integration tests.
                 LOG(INFO) << "Running in localization only mode";
                 return ActionMode::LOCALIZING;
             }
+            // This log line is needed by rdk integration tests.
             LOG(INFO) << "Running in updating mode";
             return ActionMode::UPDATING;
         }
@@ -48,6 +50,7 @@ ActionMode DetermineActionMode(std::string path_to_map,
             "set to localization mode (map_rate_sec = 0) but couldn't find "
             "apriori map to localize on");
     }
+    // This log line is needed by rdk integration tests.
     LOG(INFO) << "Running in mapping mode";
     return ActionMode::MAPPING;
 }


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-1044

* `VLOG(1)` is used for debug-level logging. Disabled by default (`v = 0`). Enable by setting `v = 1`.
* `LOG(...)` is used for info, warning, error, and fatal logging. It is not advised to change the setting for this since some of the functionalities (e.g. port forwarding) rely on obtaining the logs.

More information: https://github.com/google/glog#setting-flags