### PR TITLE
[RSDK-1255] fix slam process exit handler

### DIFF
--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -19,13 +19,13 @@ int main(int argc, char** argv) {
     // glog only supports logging to files and stderr, not stdout.
     FLAGS_logtostderr = 1;
     google::InitGoogleLogging(argv[0]);
-    struct sigaction sigIntHandler;
+    struct sigaction sigTermHandler;
 
-    sigIntHandler.sa_handler = exit_loop_handler;
-    sigemptyset(&sigIntHandler.sa_mask);
-    sigIntHandler.sa_flags = 0;
+    sigTermHandler.sa_handler = exit_loop_handler;
+    sigemptyset(&sigTermHandler.sa_mask);
+    sigTermHandler.sa_flags = 0;
 
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    sigaction(SIGTERM, &sigTermHandler, NULL);
 
     viam::SLAMServiceImpl slamService;
     viam::config::ParseAndValidateConfigParams(argc, argv, slamService);

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -19,13 +19,14 @@ int main(int argc, char** argv) {
     // glog only supports logging to files and stderr, not stdout.
     FLAGS_logtostderr = 1;
     google::InitGoogleLogging(argv[0]);
-    struct sigaction sigTermHandler;
+    struct sigaction sigHandler;
 
-    sigTermHandler.sa_handler = exit_loop_handler;
-    sigemptyset(&sigTermHandler.sa_mask);
-    sigTermHandler.sa_flags = 0;
+    sigHandler.sa_handler = exit_loop_handler;
+    sigemptyset(&sigHandler.sa_mask);
+    sigHandler.sa_flags = 0;
 
-    sigaction(SIGTERM, &sigTermHandler, NULL);
+    sigaction(SIGTERM, &sigHandler, NULL);
+    sigaction(SIGINT, &sigHandler, NULL);
 
     viam::SLAMServiceImpl slamService;
     viam::config::ParseAndValidateConfigParams(argc, argv, slamService);

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -26,13 +26,14 @@ void exit_loop_handler(int s) {
 int main(int argc, char **argv) {
     // TODO: change inputs to match args from rdk
     // https://viam.atlassian.net/jira/software/c/projects/DATA/boards/30?modal=detail&selectedIssue=DATA-179
-    struct sigaction sigTermHandler;
+    struct sigaction sigHandler;
 
-    sigTermHandler.sa_handler = exit_loop_handler;
-    sigemptyset(&sigTermHandler.sa_mask);
-    sigTermHandler.sa_flags = 0;
+    sigHandler.sa_handler = exit_loop_handler;
+    sigemptyset(&sigHandler.sa_mask);
+    sigHandler.sa_flags = 0;
 
-    sigaction(SIGTERM, &sigTermHandler, NULL);
+    sigaction(SIGTERM, &sigHandler, NULL);
+    sigaction(SIGINT, &sigHandler, NULL);
 
     viam::SLAMServiceImpl slamService;
 

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -26,13 +26,13 @@ void exit_loop_handler(int s) {
 int main(int argc, char **argv) {
     // TODO: change inputs to match args from rdk
     // https://viam.atlassian.net/jira/software/c/projects/DATA/boards/30?modal=detail&selectedIssue=DATA-179
-    struct sigaction sigIntHandler;
+    struct sigaction sigTermHandler;
 
-    sigIntHandler.sa_handler = exit_loop_handler;
-    sigemptyset(&sigIntHandler.sa_mask);
-    sigIntHandler.sa_flags = 0;
+    sigTermHandler.sa_handler = exit_loop_handler;
+    sigemptyset(&sigTermHandler.sa_mask);
+    sigTermHandler.sa_flags = 0;
 
-    sigaction(SIGINT, &sigIntHandler, NULL);
+    sigaction(SIGTERM, &sigTermHandler, NULL);
 
     viam::SLAMServiceImpl slamService;
 


### PR DESCRIPTION
Currently the slam algorithms fail to shut down when rdk attempts to close them. This PR attempts to update the exit handler to safely close out of the slam algorithms, based off information found in[ this PR](https://github.com/viamrobotics/goutils/pull/116). Will have a followup PR in rdk to clean up the integration test code

Note the changes make the clean shutdown occur only when running the slam servers with rdk. Running the binaries standalone/without managed process controlling them is not a behavior we need to support. 

https://viam.atlassian.net/browse/RSDK-1255

[RSDK-1255]: https://viam.atlassian.net/browse/RSDK-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ