### PR TITLE
[RSDK-1038] Adding use_live_data parameter to SLAM

### DIFF
--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -81,7 +81,7 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     // TODO: Remove no use_live_data definition based on sensor list after
     // integration tests have been updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
-    slamService.use_live_data = !(FLAGS_sensors.empty());
+    slamService.use_live_data = !FLAGS_sensors.empty();
 
     // Find the lua files.
     auto programLocation = boost::dll::program_location();

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -106,11 +106,7 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     // TODO: Remove no use_live_data test cases once integration tests have been
     // updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
-    if (FLAGS_sensors.empty()) {
-        slamService.offline_flag = true;
-    } else {
-        slamService.offline_flag = false;
-    }
+    slamService.offline_flag = FLAGS_sensors.empty();
 
     slamService.slam_mode =
         ConfigParamParser(slamService.config_params, "mode=");

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -77,8 +77,8 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     slamService.path_to_map = FLAGS_data_dir + "/map";
     slamService.offline_flag = !(FLAGS_use_live_data);
 
-    // TODO: Remove no use_live_data test cases once integration tests have been
-    // updated (See associated JIRA ticket:
+    // TODO: Remove no use_live_data definition based on sensor list after
+    // integration tests have been updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
     slamService.offline_flag = FLAGS_sensors.empty();
 

--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -77,6 +77,11 @@ void ParseAndValidateConfigParams(int argc, char** argv,
     slamService.path_to_map = FLAGS_data_dir + "/map";
     slamService.offline_flag = !(FLAGS_use_live_data);
 
+    // TODO: Remove no use_live_data test cases once integration tests have been
+    // updated (See associated JIRA ticket:
+    // https://viam.atlassian.net/browse/RSDK-1625)
+    slamService.offline_flag = FLAGS_sensors.empty();
+
     // Find the lua files.
     auto programLocation = boost::dll::program_location();
     auto relativePathToLuas = programLocation.parent_path().parent_path();
@@ -102,11 +107,6 @@ void ParseAndValidateConfigParams(int argc, char** argv,
             "a true delete_processed_data value is invalid when running slam "
             "in offline mode");
     }
-
-    // TODO: Remove no use_live_data test cases once integration tests have been
-    // updated (See associated JIRA ticket:
-    // https://viam.atlassian.net/browse/RSDK-1625)
-    slamService.offline_flag = FLAGS_sensors.empty();
 
     slamService.slam_mode =
         ConfigParamParser(slamService.config_params, "mode=");

--- a/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
@@ -122,11 +122,14 @@ BOOST_AUTO_TEST_CASE(OverwriteCartoConfigParam_valid_parameters) {
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_config_param) {
     ResetFlagsForTesting();
-    std::vector<std::string> args{
-        "carto_grpc_server",           "-data_dir=/path/to",
-        "-port=localhost:0",           "-sensors=lidar",
-        "-data_rate_ms=200",           "-map_rate_sec=60",
-        "-delete_processed_data=false"};
+    std::vector<std::string> args{"carto_grpc_server",
+                                  "-data_dir=/path/to",
+                                  "-port=localhost:0",
+                                  "-sensors=lidar",
+                                  "-data_rate_ms=200",
+                                  "-map_rate_sec=60",
+                                  "-delete_processed_data=false",
+                                  "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     const std::string message = "-config_param is missing";
@@ -136,11 +139,14 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_config_param) {
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_data_dir) {
     ResetFlagsForTesting();
-    std::vector<std::string> args{
-        "carto_grpc_server",           "-config_param={mode=2d}",
-        "-port=localhost:0",           "-sensors=lidar",
-        "-data_rate_ms=200",           "-map_rate_sec=60",
-        "-delete_processed_data=false"};
+    std::vector<std::string> args{"carto_grpc_server",
+                                  "-config_param={mode=2d}",
+                                  "-port=localhost:0",
+                                  "-sensors=lidar",
+                                  "-data_rate_ms=200",
+                                  "-map_rate_sec=60",
+                                  "-delete_processed_data=false",
+                                  "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     const std::string message = "-data_dir is missing";
@@ -150,11 +156,14 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_data_dir) {
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_port) {
     ResetFlagsForTesting();
-    std::vector<std::string> args{
-        "carto_grpc_server",           "-config_param={mode=2d}",
-        "-data_dir=/path/to",          "-sensors=lidar",
-        "-data_rate_ms=200",           "-map_rate_sec=60",
-        "-delete_processed_data=false"};
+    std::vector<std::string> args{"carto_grpc_server",
+                                  "-config_param={mode=2d}",
+                                  "-data_dir=/path/to",
+                                  "-sensors=lidar",
+                                  "-data_rate_ms=200",
+                                  "-map_rate_sec=60",
+                                  "-delete_processed_data=false",
+                                  "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     const std::string message = "-port is missing";
@@ -168,7 +177,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_no_slam_mode) {
         "carto_grpc_server",  "-config_param={}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "-map_rate_sec=60",   "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     const std::string message = "slam mode is missing";
@@ -182,7 +192,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_invalid_slam_mode) {
         "carto_grpc_server",  "-config_param={mode=bad}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "-map_rate_sec=60",   "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     const std::string message = "Invalid slam_mode=bad";
@@ -196,7 +207,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_valid_config) {
         "carto_grpc_server",  "-config_param={mode=2d}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "-map_rate_sec=60",   "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -247,7 +259,8 @@ BOOST_AUTO_TEST_CASE(
         "carto_grpc_server",  "-config_param=" + config_param,
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "-map_rate_sec=60",   "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -290,7 +303,8 @@ BOOST_AUTO_TEST_CASE(
         "carto_grpc_server",  "-config_param={mode=2D}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "-map_rate_sec=60",   "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -308,7 +322,8 @@ BOOST_AUTO_TEST_CASE(
                                   "-port=localhost:0",
                                   "-sensors=lidar",
                                   "-data_rate_ms=200",
-                                  "-delete_processed_data=false"};
+                                  "-delete_processed_data=false",
+                                  "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -327,7 +342,8 @@ BOOST_AUTO_TEST_CASE(
                                   "-port=localhost:0",
                                   "-sensors=lidar",
                                   "-map_rate_sec=60",
-                                  "-delete_processed_data=false"};
+                                  "-delete_processed_data=false",
+                                  "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -340,10 +356,11 @@ BOOST_AUTO_TEST_CASE(
 BOOST_AUTO_TEST_CASE(ParseAndValidateConfigParams_valid_config_no_camera) {
     ResetFlagsForTesting();
     std::vector<std::string> args{
-        "carto_grpc_server",  "-config_param={mode=2d}",
-        "-data_dir=/path/to", "-port=localhost:0",
-        "-sensors=",          "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
+        "carto_grpc_server",   "-config_param={mode=2d}",
+        "-data_dir=/path/to",  "-port=localhost:0",
+        "-sensors=",           "-data_rate_ms=200",
+        "-map_rate_sec=60",    "-delete_processed_data=false",
+        "-use_live_data=false"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -360,7 +377,8 @@ BOOST_AUTO_TEST_CASE(
         "carto_grpc_server",  "-config_param={mode=2d}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-map_rate_sec=60",
-        "-data_rate_ms=200",  "-delete_processed_data=true"};
+        "-data_rate_ms=200",  "-delete_processed_data=true",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -377,7 +395,8 @@ BOOST_AUTO_TEST_CASE(
         "carto_grpc_server",  "-config_param={mode=2d}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=lidar",     "-map_rate_sec=60",
-        "-data_rate_ms=200",  "-delete_processed_data=false"};
+        "-data_rate_ms=200",  "-delete_processed_data=false",
+        "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -391,10 +410,11 @@ BOOST_AUTO_TEST_CASE(
     ParseAndValidateConfigParams_valid_offline_config_with_true_delete_processed_data) {
     ResetFlagsForTesting();
     std::vector<std::string> args{
-        "carto_grpc_server",  "-config_param={mode=2d}",
-        "-data_dir=/path/to", "-port=localhost:0",
-        "-sensors=",          "-map_rate_sec=60",
-        "-data_rate_ms=200",  "-delete_processed_data=true"};
+        "carto_grpc_server",   "-config_param={mode=2d}",
+        "-data_dir=/path/to",  "-port=localhost:0",
+        "-sensors=",           "-map_rate_sec=60",
+        "-data_rate_ms=200",   "-delete_processed_data=true",
+        "-use_live_data=false"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -409,10 +429,11 @@ BOOST_AUTO_TEST_CASE(
     ParseAndValidateConfigParams_valid_offline_config_with_false_delete_processed_data) {
     ResetFlagsForTesting();
     std::vector<std::string> args{
-        "carto_grpc_server",  "-config_param={mode=2d}",
-        "-data_dir=/path/to", "-port=localhost:0",
-        "-sensors=",          "-map_rate_sec=60",
-        "-data_rate_ms=200",  "-delete_processed_data=false"};
+        "carto_grpc_server",   "-config_param={mode=2d}",
+        "-data_dir=/path/to",  "-port=localhost:0",
+        "-sensors=",           "-map_rate_sec=60",
+        "-data_rate_ms=200",   "-delete_processed_data=false",
+        "-use_live_data=false"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -432,7 +453,7 @@ BOOST_AUTO_TEST_CASE(
     std::vector<std::string> args{
         "carto_grpc_server", "-config_param={mode=2d}", "-data_dir=/path/to",
         "-port=localhost:0", "-sensors=lidar",          "-map_rate_sec=60",
-        "-data_rate_ms=200"};
+        "-data_rate_ms=200", "-use_live_data=true"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
@@ -449,13 +470,49 @@ BOOST_AUTO_TEST_CASE(
         "carto_grpc_server",  "-config_param={mode=2d}",
         "-data_dir=/path/to", "-port=localhost:0",
         "-sensors=",          "-map_rate_sec=60",
-        "-data_rate_ms=200"};
+        "-data_rate_ms=200",  "-use_live_data=false"};
     int argc = args.size();
     char** argv = toCharArrayArray(args);
     SLAMServiceImpl slamService;
     ParseAndValidateConfigParams(argc, argv, slamService);
     BOOST_TEST(slamService.offline_flag == true);
     BOOST_TEST(slamService.delete_processed_data == false);
+    delete argv;
+}
+
+// TODO: Remove no use_live_data test cases once integration tests have been
+// updated (See associated JIRA ticket:
+// https://viam.atlassian.net/browse/RSDK-1625)
+
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateConfigParams_online_config_no_use_live_data) {
+    ResetFlagsForTesting();
+    std::vector<std::string> args{
+        "carto_grpc_server",  "-config_param={mode=2d}",
+        "-data_dir=/path/to", "-port=localhost:0",
+        "-sensors=lidar",     "-data_rate_ms=200",
+        "-map_rate_sec=60",   "-delete_processed_data=false"};
+    int argc = args.size();
+    char** argv = toCharArrayArray(args);
+    SLAMServiceImpl slamService;
+    ParseAndValidateConfigParams(argc, argv, slamService);
+    BOOST_TEST(slamService.offline_flag == false);
+    delete argv;
+}
+
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateConfigParams_offline_config_no_use_live_data) {
+    ResetFlagsForTesting();
+    std::vector<std::string> args{
+        "carto_grpc_server",  "-config_param={mode=2d}",
+        "-data_dir=/path/to", "-port=localhost:0",
+        "-sensors=",          "-data_rate_ms=200",
+        "-map_rate_sec=60",   "-delete_processed_data=false"};
+    int argc = args.size();
+    char** argv = toCharArrayArray(args);
+    SLAMServiceImpl slamService;
+    ParseAndValidateConfigParams(argc, argv, slamService);
+    BOOST_TEST(slamService.offline_flag == true);
     delete argv;
 }
 

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -468,10 +468,10 @@ std::string SLAMServiceImpl::GetNextDataFileOnline() {
 }
 
 std::string SLAMServiceImpl::GetNextDataFile() {
-    if (!use_live_data) {
-        return GetNextDataFileOffline();
+    if (use_live_data) {
+        return GetNextDataFileOnline();
     }
-    return GetNextDataFileOnline();
+    return GetNextDataFileOffline();
 }
 
 void SLAMServiceImpl::StartSaveMap() {
@@ -500,7 +500,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
             std::chrono::duration<double, std::milli> time_elapsed_msec =
                 std::chrono::high_resolution_clock::now() - start;
             if ((time_elapsed_msec >= map_rate_sec) ||
-                (!(use_live_data) && finished_processing_offline)) {
+                (!use_live_data && finished_processing_offline)) {
                 break;
             }
             if (map_rate_sec - time_elapsed_msec >=
@@ -515,7 +515,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
         const std::string filename_with_timestamp =
             viam::io::MakeFilenameWithTimestamp(path_to_map);
 
-        if (!(use_live_data) && finished_processing_offline) {
+        if (!use_live_data && finished_processing_offline) {
             {
                 std::lock_guard<std::mutex> lk(map_builder_mutex);
                 map_builder.SaveMapToFile(true, filename_with_timestamp);

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -468,7 +468,7 @@ std::string SLAMServiceImpl::GetNextDataFileOnline() {
 }
 
 std::string SLAMServiceImpl::GetNextDataFile() {
-    if (offline_flag) {
+    if (!use_live_data) {
         return GetNextDataFileOffline();
     }
     return GetNextDataFileOnline();
@@ -500,7 +500,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
             std::chrono::duration<double, std::milli> time_elapsed_msec =
                 std::chrono::high_resolution_clock::now() - start;
             if ((time_elapsed_msec >= map_rate_sec) ||
-                (offline_flag && finished_processing_offline)) {
+                (!(use_live_data) && finished_processing_offline)) {
                 break;
             }
             if (map_rate_sec - time_elapsed_msec >=
@@ -515,7 +515,7 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
         const std::string filename_with_timestamp =
             viam::io::MakeFilenameWithTimestamp(path_to_map);
 
-        if (offline_flag && finished_processing_offline) {
+        if (!(use_live_data) && finished_processing_offline) {
             {
                 std::lock_guard<std::mutex> lk(map_builder_mutex);
                 map_builder.SaveMapToFile(true, filename_with_timestamp);
@@ -613,7 +613,7 @@ void SLAMServiceImpl::ProcessDataAndStartSavingMaps(double data_start_time) {
         std::lock_guard<std::mutex> lk(map_builder_mutex);
         map_builder.map_builder_->FinishTrajectory(trajectory_id);
     }
-    if (offline_flag) {
+    if (!use_live_data) {
         BackupLatestMap();
         {
             std::unique_lock<std::shared_mutex> optimization_lock(

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -109,7 +109,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
     std::chrono::seconds map_rate_sec;
     std::string slam_mode;
     std::atomic<bool> optimize_on_start{false};
-    std::atomic<bool> offline_flag{false};
+    std::atomic<bool> use_live_data{false};
     bool delete_processed_data = false;
 
     // -- Cartographer specific config params:

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -793,10 +793,6 @@ void ParseAndValidateArguments(const vector<string> &args,
             "invalid use_live_data value, set to either true or false");
     }
 
-    if (slamService.slam_port.empty()) {
-        throw runtime_error("No gRPC port given");
-    }
-
     auto delete_processed_data = ArgParser(args, "-delete_processed_data=");
     // TODO: Remove empty check once PR #1689 is submitted
     // https://github.com/viamrobotics/rdk/pull/1689 This will allow integration

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -580,7 +580,7 @@ void SLAMServiceImpl::SaveAtlasAsOsaWithTimestamp(ORB_SLAM3::System *SLAM) {
         auto start = std::chrono::high_resolution_clock::now();
         string path_save_file_name =
             utils::MakeFilenameWithTimestamp(path_to_map, camera_name);
-        if (offlineFlag && finished_processing_offline) {
+        if (!use_live_data && finished_processing_offline) {
             {
                 std::lock_guard<std::mutex> lock(slam_mutex);
                 SLAM->SaveAtlasAsOsaWithTimestamp(path_save_file_name);
@@ -776,21 +776,23 @@ void ParseAndValidateArguments(const vector<string> &args,
     }
 
     slamService.camera_name = ArgParser(args, "-sensors=");
-    if (slamService.camera_name.empty()) {
-        BOOST_LOG_TRIVIAL(info) << "No camera given -> running in offline mode";
-    }
 
     auto use_live_data = ArgParser(args, "-use_live_data=");
     // TODO: Remove use_live_data == "" check once integration tests have been
     // updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
     if (use_live_data == "") {
-        slamService.offlineFlag = (slamService.camera_name.empty());
+        slamService.use_live_data = !(slamService.camera_name.empty());
     } else if (use_live_data == "true" || use_live_data == "false") {
-        slamService.offlineFlag = !(use_live_data == "true");
+        slamService.use_live_data = (use_live_data == "true");
     } else {
         throw runtime_error(
             "invalid use_live_data value, set to either true or false");
+    }
+
+    if (slamService.use_live_data && slamService.camera_name.empty()) {
+        throw runtime_error(
+            "a true use_live_data value is invalid when no sensors are given");
     }
 
     auto delete_processed_data = ArgParser(args, "-delete_processed_data=");
@@ -808,7 +810,7 @@ void ParseAndValidateArguments(const vector<string> &args,
             "invalid delete_processed_data value, set to either true or false");
     }
 
-    if (slamService.offlineFlag && slamService.delete_processed_data) {
+    if (!(slamService.use_live_data) && slamService.delete_processed_data) {
         throw runtime_error(
             "a true delete_processed_data value is invalid when running slam "
             "in offline mode");
@@ -816,7 +818,7 @@ void ParseAndValidateArguments(const vector<string> &args,
 
     string local_viewer = ArgParser(args, "--localView=");
     boost::algorithm::to_lower(local_viewer);
-    if ((local_viewer == "true") && (slamService.offlineFlag)) {
+    if ((local_viewer == "true") && !(slamService.use_live_data)) {
         BOOST_LOG_TRIVIAL(info) << "Running with local viewer";
         slamService.local_viewer_flag = true;
     } else {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -795,6 +795,7 @@ void ParseAndValidateArguments(const vector<string> &args,
             "a true use_live_data value is invalid when no sensors are given");
     }
 
+    auto delete_processed_data = ArgParser(args, "-delete_processed_data=");
     if (delete_processed_data == "true" || delete_processed_data == "false") {
         slamService.delete_processed_data = (delete_processed_data == "true");
     } else {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -782,7 +782,7 @@ void ParseAndValidateArguments(const vector<string> &args,
     // updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
     if (use_live_data == "") {
-        slamService.use_live_data = !(slamService.camera_name.empty());
+        slamService.use_live_data = !slamService.camera_name.empty();
     } else if (use_live_data == "true" || use_live_data == "false") {
         slamService.use_live_data = (use_live_data == "true");
     } else {
@@ -803,7 +803,7 @@ void ParseAndValidateArguments(const vector<string> &args,
             "invalid delete_processed_data value, set to either true or false");
     }
 
-    if (!(slamService.use_live_data) && slamService.delete_processed_data) {
+    if (!slamService.use_live_data && slamService.delete_processed_data) {
         throw runtime_error(
             "a true delete_processed_data value is invalid when running slam "
             "in offline mode");
@@ -811,7 +811,7 @@ void ParseAndValidateArguments(const vector<string> &args,
 
     string local_viewer = ArgParser(args, "--localView=");
     boost::algorithm::to_lower(local_viewer);
-    if ((local_viewer == "true") && !(slamService.use_live_data)) {
+    if ((local_viewer == "true") && !slamService.use_live_data) {
         BOOST_LOG_TRIVIAL(info) << "Running with local viewer";
         slamService.local_viewer_flag = true;
     } else {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -781,7 +781,7 @@ void ParseAndValidateArguments(const vector<string> &args,
     }
 
     auto use_live_data = ArgParser(args, "-use_live_data=");
-    // TODO: Remove no use_live_data test cases once integration tests have been
+    // TODO: Remove use_live_data == "" check once integration tests have been
     // updated (See associated JIRA ticket:
     // https://viam.atlassian.net/browse/RSDK-1625)
     if (use_live_data == "") {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -58,7 +58,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
     chrono::milliseconds frame_delay_msec;
     chrono::seconds map_rate_sec;
     double yamlTime;
-    std::atomic<bool> offlineFlag{false};
+    std::atomic<bool> use_live_data{false};
     bool delete_processed_data = false;
     bool local_viewer_flag = false;
     bool pure_localization_mode = false;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
         if (is_regular_file(p) && p.extension() == ".yaml") {
             std::time_t timestamp = last_write_time(p);
             if (timestamp > latest_tm) {
-                if (slamService.offlineFlag ||
+                if (!slamService.use_live_data ||
                     p.stem().string().find(slamService.camera_name) !=
                         string::npos) {
                     latest = p;
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
 
     string full_path_to_settings =
         slamService.path_to_settings + "/" + latest.filename().string();
-    if (slamService.offlineFlag) {
+    if (!slamService.use_live_data) {
         if (myYAML.find("_data_") != string::npos)
             slamService.camera_name = myYAML.substr(0, myYAML.find("_data_"));
         else {
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
         SLAM->GetAtlas()->ChangeMap(largestMap);
     }
 
-    if (slamService.offlineFlag) {
+    if (!slamService.use_live_data) {
         BOOST_LOG_TRIVIAL(info) << "Running in offline mode";
         slamService.StartSaveAtlasAsOsa(SLAM.get());
         slamService.ProcessDataOffline(SLAM.get());

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -31,7 +31,9 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_no_args) {
         "-port=grpc_port "
         "-sensors=sensor_name "
         "-data_rate_ms=frame_delay "
-        "-map_rate_sec=map_rate_sec";
+        "-map_rate_sec=map_rate_sec "
+        "-delete_processed_data=delete_data "
+        "-use_live_data=offline_or_online";
     checkParseAndValidateArgumentsException(args, message);
 }
 
@@ -42,6 +44,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_no_data_dir) {
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
                               "-delete_processed_data=false",
+                              "-use_live_data=true",
                               "-unknown=unknown"};
     const string message = "No data directory given";
     checkParseAndValidateArgumentsException(args, message);
@@ -54,7 +57,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_no_slam_mode) {
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     const string message = "No SLAM mode given";
     checkParseAndValidateArgumentsException(args, message);
 }
@@ -66,17 +70,18 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_slam_mode) {
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     const string message = "Invalid slam_mode=bad";
     checkParseAndValidateArgumentsException(args, message);
 }
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_no_slam_port) {
     const vector<string> args{
-        "-data_dir=/path/to", "-config_param={mode=rgbd}",
-        "-sensors=color",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false",
-        "-unknown=unknown"};
+        "-data_dir=/path/to",  "-config_param={mode=rgbd}",
+        "-sensors=color",      "-data_rate_ms=200",
+        "-map_rate_sec=60",    "-delete_processed_data=false",
+        "-use_live_data=true", "-unknown=unknown"};
     const string message = "No gRPC port given";
     checkParseAndValidateArgumentsException(args, message);
 }
@@ -88,7 +93,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config_no_data_rate_msec) {
                               "-sensors=color",
                               "-data_rate_ms=",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     const string message = "a data_rate_ms value is required";
     checkParseAndValidateArgumentsException(args, message);
 }
@@ -100,7 +106,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config_no_map_rate_sec) {
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     const string message = "a map_rate_sec value is required";
     checkParseAndValidateArgumentsException(args, message);
 }
@@ -112,7 +119,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config) {
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.path_to_vocab == "/path/to/config/ORBvoc.txt");
@@ -137,7 +145,8 @@ BOOST_AUTO_TEST_CASE(
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=true"};
+                              "-delete_processed_data=true",
+                              "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.slam_mode == "rgbd");
@@ -150,7 +159,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config_no_camera) {
                               "-sensors=",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.camera_name == "");
@@ -165,7 +175,8 @@ BOOST_AUTO_TEST_CASE(
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=true"};
+                              "-delete_processed_data=true",
+                              "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.offlineFlag == false);
@@ -180,7 +191,8 @@ BOOST_AUTO_TEST_CASE(
                               "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.offlineFlag == false);
@@ -195,7 +207,8 @@ BOOST_AUTO_TEST_CASE(
                               "-sensors=",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=true"};
+                              "-delete_processed_data=true",
+                              "-use_live_data=false"};
     const string message =
         "a true delete_processed_data value is invalid when running slam in "
         "offline mode";
@@ -210,7 +223,8 @@ BOOST_AUTO_TEST_CASE(
                               "-sensors=",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=false"};
+                              "-delete_processed_data=false",
+                              "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.offlineFlag == true);
@@ -224,9 +238,24 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_delete_processed_data) {
                               "-sensors=",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
-                              "-delete_processed_data=gibberish"};
+                              "-delete_processed_data=gibberish"
+                              "-use_live_data=true"};
     const string message =
         "invalid delete_processed_data value, set to either true or false";
+    checkParseAndValidateArgumentsException(args, message);
+}
+
+BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_use_live_data) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=color",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=false",
+                              "-use_live_data=gibberish"};
+    const string message =
+        "invalid use_live_data value, set to either true or false";
     checkParseAndValidateArgumentsException(args, message);
 }
 
@@ -238,7 +267,8 @@ BOOST_AUTO_TEST_CASE(
     ParseAndValidateArguments_online_with_no_delete_processed_data) {
     const vector<string> args{"-data_dir=/path/to", "-config_param={mode=rgbd}",
                               "-port=20000",        "-sensors=color",
-                              "-data_rate_ms=200",  "-map_rate_sec=60"};
+                              "-data_rate_ms=200",  "-map_rate_sec=60",
+                              "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.offlineFlag == false);
@@ -248,12 +278,34 @@ BOOST_AUTO_TEST_CASE(
 BOOST_AUTO_TEST_CASE(
     ParseAndValidateArguments_offline_with_no_delete_processed_data) {
     const vector<string> args{
+        "-data_dir=/path/to",  "-config_param={mode=rgbd}", "-port=20000",
+        "-sensors=",           "-data_rate_ms=200",         "-map_rate_sec=60",
+        "-use_live_data=false"};
+    SLAMServiceImpl slamService;
+    utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.delete_processed_data == false);
+}
+
+// TODO: Remove no use_live_data test cases once integration tests have been
+// updated (See associated JIRA ticket:
+// https://viam.atlassian.net/browse/RSDK-1625)
+BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
+    const vector<string> args{"-data_dir=/path/to", "-config_param={mode=rgbd}",
+                              "-port=20000",        "-sensors=color",
+                              "-data_rate_ms=200",  "-map_rate_sec=60"};
+    SLAMServiceImpl slamService;
+    utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.offlineFlag == false);
+}
+
+BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
+    const vector<string> args{
         "-data_dir=/path/to", "-config_param={mode=rgbd}", "-port=20000",
         "-sensors=",          "-data_rate_ms=200",         "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.offlineFlag == true);
-    BOOST_TEST(slamService.delete_processed_data == false);
 }
 
 BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp_missing_timestamp) {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -257,6 +257,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.camera_name == "color");
     BOOST_TEST(slamService.use_live_data == true);
 }
 
@@ -272,6 +273,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.camera_name == "color");
     BOOST_TEST(slamService.use_live_data == false);
 }
 
@@ -302,6 +304,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.camera_name == "");
     BOOST_TEST(slamService.use_live_data == false);
 }
 
@@ -325,7 +328,8 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_invalid_use_live_data) {
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
     const vector<string> args{"-data_dir=/path/to", "-config_param={mode=rgbd}",
                               "-port=20000",        "-sensors=color",
-                              "-data_rate_ms=200",  "-map_rate_sec=60"};
+                              "-data_rate_ms=200",  "-delete_processed_data=false",
+                              "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.use_live_data == true);
@@ -334,14 +338,13 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
     const vector<string> args{
         "-data_dir=/path/to", "-config_param={mode=rgbd}", "-port=20000",
-        "-sensors=",          "-data_rate_ms=200",         "-map_rate_sec=60"};
+        "-sensors=",          "-data_rate_ms=200",         "-delete_processed_data=false",
+        "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.use_live_data == false);
 }
 
-=======
->>>>>>> 31f4c0b921f90385bf8c997ad017878153d1a503
 BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp_missing_timestamp) {
     // Provide a filename with a missing timestamp
     std::string timestamp = "no-timestamp";
@@ -368,6 +371,8 @@ BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp) {
 
 BOOST_AUTO_TEST_CASE(FindFrameIndex_Closest_no_files) {
     const string configTimeString = "2022-01-01T01:00:00.0000Z";
+    const auto configTime = utils::ReadTimeFromTimestamp(configTimeString);
+    vector<string> files;
     double timeInterest;
     BOOST_TEST(utils::FindFrameIndex(files, "mono", "",
                                      utils::FileParserMethod::Closest,

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -326,10 +326,11 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_invalid_use_live_data) {
 // updated (See associated JIRA ticket:
 // https://viam.atlassian.net/browse/RSDK-1625)
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
-    const vector<string> args{"-data_dir=/path/to", "-config_param={mode=rgbd}",
-                              "-port=20000",        "-sensors=color",
-                              "-data_rate_ms=200",  "-delete_processed_data=false",
-                              "-map_rate_sec=60"};
+    const vector<string> args{
+        "-data_dir=/path/to", "-config_param={mode=rgbd}",
+        "-port=20000",        "-sensors=color",
+        "-data_rate_ms=200",  "-delete_processed_data=false",
+        "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.use_live_data == true);
@@ -337,8 +338,9 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
     const vector<string> args{
-        "-data_dir=/path/to", "-config_param={mode=rgbd}", "-port=20000",
-        "-sensors=",          "-data_rate_ms=200",         "-delete_processed_data=false",
+        "-data_dir=/path/to", "-config_param={mode=rgbd}",
+        "-port=20000",        "-sensors=",
+        "-data_rate_ms=200",  "-delete_processed_data=false",
         "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config) {
                chrono::milliseconds(200).count());
     BOOST_TEST(slamService.map_rate_sec.count() == chrono::seconds(60).count());
     BOOST_TEST(slamService.camera_name == "color");
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.use_live_data == true);
     BOOST_TEST(slamService.delete_processed_data == false);
 }
 
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_valid_config_no_camera) {
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
     BOOST_TEST(slamService.camera_name == "");
-    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.use_live_data == false);
 }
 
 BOOST_AUTO_TEST_CASE(
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.use_live_data == true);
     BOOST_TEST(slamService.delete_processed_data == true);
 }
 
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.use_live_data == true);
     BOOST_TEST(slamService.delete_processed_data == false);
 }
 
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.use_live_data == false);
     BOOST_TEST(slamService.delete_processed_data == false);
 }
 
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_delete_processed_data) {
     const vector<string> args{"-data_dir=/path/to",
                               "-config_param={mode=rgbd}",
                               "-port=20000",
-                              "-sensors=",
+                              "-sensors=color",
                               "-data_rate_ms=200",
                               "-map_rate_sec=60",
                               "-delete_processed_data=gibberish"
@@ -245,7 +245,67 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_delete_processed_data) {
     checkParseAndValidateArgumentsException(args, message);
 }
 
-BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_invalid_use_live_data) {
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateArguments_config_with_true_use_live_data_and_sensors) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=color",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=true",
+                              "-use_live_data=true"};
+    SLAMServiceImpl slamService;
+    utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.use_live_data == true);
+}
+
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateArguments_config_with_false_use_live_data_and_sensors) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=color",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=false",
+                              "-use_live_data=false"};
+    SLAMServiceImpl slamService;
+    utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.use_live_data == false);
+}
+
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateArguments_config_with_true_use_live_data_and_no_sensors) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=true",
+                              "-use_live_data=true"};
+    const string message =
+        "a true use_live_data value is invalid when no sensors are given";
+    checkParseAndValidateArgumentsException(args, message);
+}
+
+BOOST_AUTO_TEST_CASE(
+    ParseAndValidateArguments_config_with_false_use_live_data_and_no_sensors) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=false",
+                              "-use_live_data=false"};
+    SLAMServiceImpl slamService;
+    utils::ParseAndValidateArguments(args, slamService);
+    BOOST_TEST(slamService.use_live_data == false);
+}
+
+BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_invalid_use_live_data) {
     const vector<string> args{"-data_dir=/path/to",
                               "-config_param={mode=rgbd}",
                               "-port=20000",
@@ -271,7 +331,7 @@ BOOST_AUTO_TEST_CASE(
                               "-use_live_data=true"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.use_live_data == true);
     BOOST_TEST(slamService.delete_processed_data == false);
 }
 
@@ -283,7 +343,7 @@ BOOST_AUTO_TEST_CASE(
         "-use_live_data=false"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.use_live_data == false);
     BOOST_TEST(slamService.delete_processed_data == false);
 }
 
@@ -296,7 +356,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
                               "-data_rate_ms=200",  "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == false);
+    BOOST_TEST(slamService.use_live_data == true);
 }
 
 BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
@@ -305,7 +365,7 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
         "-sensors=",          "-data_rate_ms=200",         "-map_rate_sec=60"};
     SLAMServiceImpl slamService;
     utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.offlineFlag == true);
+    BOOST_TEST(slamService.use_live_data == false);
 }
 
 BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp_missing_timestamp) {


### PR DESCRIPTION
Adds a new argument, 'use_live_data' to SLAM, defined in the [SLAM usability scope doc](https://docs.google.com/document/d/1RsT-c0QOtkMKa-rwUGY0-emUmKIRSaO3mzT1v6MtFjk/edit?usp=sharing), that is responsible for indicating if newly generated data or previously generated data should be used during this run. This is replacing the previous offlineFlag that was auto populated based on the presence or lack of sensors. 

This PR is made in conjunction with the PR in RDK that adds use_live_data both to the list of arguments passed to SLAM but also the configs in testing.

In order to ensure backwards compatibility currently in orbslam we check if the use_live_data argument exists and if not, we use the old method of the sensor list to determine online/offline mode for cartographer we currently over write the offline_flag with the state of the sensor list. This means that currently there is no way to run in offline mode when a sensor is given and no way to run in online mode when no sensor is given. These features will be added back in the PR to remove backwards compatibility

JIRA Ticket: [RSDK-1038](https://viam.atlassian.net/browse/RSDK-1038)
Associated PR: [#1729](https://github.com/viamrobotics/rdk/pull/1729)

Remove backwards compatibility JIRA Ticket:  [RSDK-1625](https://viam.atlassian.net/browse/RSDK-1625)



[RSDK-1038]: https://viam.atlassian.net/browse/RSDK-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ