### PR TITLE
nick/denote-orbslam-not-supported-on-macos

### DIFF
--- a/slam-libraries/README.md
+++ b/slam-libraries/README.md
@@ -45,6 +45,8 @@ For more information see [the official ORB_SLAM3 Repo](https://github.com/UZ-SLA
 
 #### Getting started
 
+##### NOTE: Orbslam is not currently supported on MacOS
+
 To automatically install dependencies run
 ```
 make setuporb


### PR DESCRIPTION
- Update README.md to denote orbslam is not supported on macos