### PR TITLE
RSDK-1625 Remove Backwards Compatibility with use_live_data

### DIFF
--- a/slam-libraries/viam-cartographer/src/slam_service/config.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config.cc
@@ -78,11 +78,6 @@ void ParseAndValidateConfigParams(int argc, char** argv,
             "a true use_live_data value is invalid when no sensors are given");
     }
 
-    // TODO: Remove no use_live_data definition based on sensor list after
-    // integration tests have been updated (See associated JIRA ticket:
-    // https://viam.atlassian.net/browse/RSDK-1625)
-    slamService.use_live_data = !FLAGS_sensors.empty();
-
     // Find the lua files.
     auto programLocation = boost::dll::program_location();
     auto relativePathToLuas = programLocation.parent_path().parent_path();

--- a/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/config_test.cc
@@ -513,41 +513,6 @@ BOOST_AUTO_TEST_CASE(
     delete argv;
 }
 
-// TODO: Remove no use_live_data test cases once integration tests have been
-// updated (See associated JIRA ticket:
-// https://viam.atlassian.net/browse/RSDK-1625)
-BOOST_AUTO_TEST_CASE(
-    ParseAndValidateConfigParams_config_no_use_live_data_with_sensors) {
-    ResetFlagsForTesting();
-    std::vector<std::string> args{
-        "carto_grpc_server",  "-config_param={mode=2d}",
-        "-data_dir=/path/to", "-port=localhost:0",
-        "-sensors=lidar",     "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
-    int argc = args.size();
-    char** argv = toCharArrayArray(args);
-    SLAMServiceImpl slamService;
-    ParseAndValidateConfigParams(argc, argv, slamService);
-    BOOST_TEST(slamService.use_live_data == true);
-    delete argv;
-}
-
-BOOST_AUTO_TEST_CASE(
-    ParseAndValidateConfigParams_config_no_use_live_data_with_no_sensors) {
-    ResetFlagsForTesting();
-    std::vector<std::string> args{
-        "carto_grpc_server",  "-config_param={mode=2d}",
-        "-data_dir=/path/to", "-port=localhost:0",
-        "-sensors=",          "-data_rate_ms=200",
-        "-map_rate_sec=60",   "-delete_processed_data=false"};
-    int argc = args.size();
-    char** argv = toCharArrayArray(args);
-    SLAMServiceImpl slamService;
-    ParseAndValidateConfigParams(argc, argv, slamService);
-    BOOST_TEST(slamService.use_live_data == false);
-    delete argv;
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -778,12 +778,7 @@ void ParseAndValidateArguments(const vector<string> &args,
     slamService.camera_name = ArgParser(args, "-sensors=");
 
     auto use_live_data = ArgParser(args, "-use_live_data=");
-    // TODO: Remove use_live_data == "" check once integration tests have been
-    // updated (See associated JIRA ticket:
-    // https://viam.atlassian.net/browse/RSDK-1625)
-    if (use_live_data == "") {
-        slamService.use_live_data = !slamService.camera_name.empty();
-    } else if (use_live_data == "true" || use_live_data == "false") {
+    if (use_live_data == "true" || use_live_data == "false") {
         slamService.use_live_data = (use_live_data == "true");
     } else {
         throw runtime_error(

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -322,31 +322,6 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_invalid_use_live_data) {
     checkParseAndValidateArgumentsException(args, message);
 }
 
-// TODO: Remove no use_live_data test cases once integration tests have been
-// updated (See associated JIRA ticket:
-// https://viam.atlassian.net/browse/RSDK-1625)
-BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_online_with_no_live_data) {
-    const vector<string> args{
-        "-data_dir=/path/to", "-config_param={mode=rgbd}",
-        "-port=20000",        "-sensors=color",
-        "-data_rate_ms=200",  "-delete_processed_data=false",
-        "-map_rate_sec=60"};
-    SLAMServiceImpl slamService;
-    utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.use_live_data == true);
-}
-
-BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_offline_with_no_live_data) {
-    const vector<string> args{
-        "-data_dir=/path/to", "-config_param={mode=rgbd}",
-        "-port=20000",        "-sensors=",
-        "-data_rate_ms=200",  "-delete_processed_data=false",
-        "-map_rate_sec=60"};
-    SLAMServiceImpl slamService;
-    utils::ParseAndValidateArguments(args, slamService);
-    BOOST_TEST(slamService.use_live_data == false);
-}
-
 BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp_missing_timestamp) {
     // Provide a filename with a missing timestamp
     std::string timestamp = "no-timestamp";

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_test.cc
@@ -322,6 +322,20 @@ BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_invalid_use_live_data) {
     checkParseAndValidateArgumentsException(args, message);
 }
 
+BOOST_AUTO_TEST_CASE(ParseAndValidateArguments_config_no_use_live_data) {
+    const vector<string> args{"-data_dir=/path/to",
+                              "-config_param={mode=rgbd}",
+                              "-port=20000",
+                              "-sensors=color",
+                              "-data_rate_ms=200",
+                              "-map_rate_sec=60",
+                              "-delete_processed_data=false",
+                              "-use_live_data="};
+    const string message =
+        "invalid use_live_data value, set to either true or false";
+    checkParseAndValidateArgumentsException(args, message);
+}
+
 BOOST_AUTO_TEST_CASE(ReadTimeFromTimestamp_missing_timestamp) {
     // Provide a filename with a missing timestamp
     std::string timestamp = "no-timestamp";


### PR DESCRIPTION
This PR removes the associated code and test cases that allowed backwards compatibility between offline/online mode being determined by the `sensors` list (old) vs the `use_live_data` parameter (new). This PR will be merged after the RDK PR associated with `use_live_data` has been merged.

Associated PR: [#1729](https://github.com/viamrobotics/rdk/pull/1729)
JIRA Ticket: [RSDK-1625](https://viam.atlassian.net/browse/RSDK-1625)

[RSDK-1625]: https://viam.atlassian.net/browse/RSDK-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ