### PR TITLE
RSDK-1073 Add GetPositionNew to Cartographer

### DIFF
--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -68,9 +68,6 @@ std::atomic<bool> b_continue_session{true};
     myPose->set_z(global_pose.translation().z());
 
     // Set component_reference for our response
-    // auto *myComponentReference = response->mutable_component_reference();
-    // myComponentReference->set__component_reference(camera_name)
-
     response->set_component_reference(camera_name);
 
     // Set extra for our response (currently stores quaternion)

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -69,9 +69,6 @@ std::atomic<bool> b_continue_session{true};
     myPose->set_y(global_pose.translation().y());
     myPose->set_z(global_pose.translation().z());
 
-    // Set component_reference for our response
-    response->set_component_reference(camera_name);
-
     // Set extra for our response (currently stores quaternion)
     google::protobuf::Struct *q;
     google::protobuf::Struct *extra = response->mutable_extra();
@@ -84,6 +81,9 @@ std::atomic<bool> b_continue_session{true};
         global_pose.rotation().y());
     q->mutable_fields()->operator[]("kmag").set_number_value(
         global_pose.rotation().z());
+
+    // Set component_reference for our response
+    response->set_component_reference(camera_name);
 
     return grpc::Status::OK;
 }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -52,8 +52,6 @@ std::atomic<bool> b_continue_session{true};
     return grpc::Status::OK;
 }
 
-// TODO 01/10/2023: Remove current GetPosition and rename this implementation to
-// GetPosition in PR for RSDK-1066
 ::grpc::Status SLAMServiceImpl::GetPositionNew(
     ServerContext *context, const GetPositionNewRequest *request,
     GetPositionNewResponse *response) {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -71,10 +71,10 @@ std::atomic<bool> b_continue_session{true};
     // auto *myComponentReference = response->mutable_component_reference();
     // myComponentReference->set__component_reference(camera_name)
 
-    response->set_component_reference(camera_name)
+    response->set_component_reference(camera_name);
 
-        // Set extra for our response (currently stores quaternion)
-        google::protobuf::Struct *q;
+    // Set extra for our response (currently stores quaternion)
+    google::protobuf::Struct *q;
     google::protobuf::Struct *extra = response->mutable_extra();
     q = extra->mutable_fields()->operator[]("quat").mutable_struct_value();
     q->mutable_fields()->operator[]("real").set_number_value(

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -52,6 +52,8 @@ std::atomic<bool> b_continue_session{true};
     return grpc::Status::OK;
 }
 
+// TODO 01/10/2023: Remove current GetPosition and rename this implementation to
+// GetPosition in PR for RSDK-1066
 ::grpc::Status SLAMServiceImpl::GetPositionNew(
     ServerContext *context, const GetPositionNewRequest *request,
     GetPositionNewResponse *response) {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -51,8 +51,9 @@ class SLAMServiceImpl final : public SLAMService::Service {
                                const GetPositionRequest *request,
                                GetPositionResponse *response) override;
 
-    // GetPosition returns the relative pose of the robot w.r.t the "origin"
-    // of the map, along with a reference component.
+    // GetPositionNew returns the relative pose of the robot w.r.t the "origin"
+    // of the map, which is the starting point from where the map was initially
+    // created along with a component reference.
     ::grpc::Status GetPositionNew(ServerContext *context,
                                   const GetPositionNewRequest *request,
                                   GetPositionNewResponse *response) override;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -29,6 +29,8 @@ using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
+using viam::service::slam::v1::GetPositionNewRequest;
+using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {
@@ -48,6 +50,12 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetPosition(ServerContext *context,
                                const GetPositionRequest *request,
                                GetPositionResponse *response) override;
+
+    // GetPosition returns the relative pose of the robot w.r.t the "origin"
+    // of the map, along with a reference component.
+    ::grpc::Status GetPositionNew(ServerContext *context,
+                               const GetPositionNewRequest *request,
+                               GetPositionNewResponse *response) override;
 
     // GetMap returns either an image or a pointcloud, depending on the MIME
     // type requested.

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -27,10 +27,10 @@ using viam::common::v1::Pose;
 using viam::common::v1::PoseInFrame;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
-using viam::service::slam::v1::GetPositionRequest;
-using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
+using viam::service::slam::v1::GetPositionRequest;
+using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {
@@ -54,8 +54,8 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // GetPosition returns the relative pose of the robot w.r.t the "origin"
     // of the map, along with a reference component.
     ::grpc::Status GetPositionNew(ServerContext *context,
-                               const GetPositionNewRequest *request,
-                               GetPositionNewResponse *response) override;
+                                  const GetPositionNewRequest *request,
+                                  GetPositionNewResponse *response) override;
 
     // GetMap returns either an image or a pointcloud, depending on the MIME
     // type requested.


### PR DESCRIPTION
This PR adds the `GetPositionNew` endpoint to cartographer. This `GetPositionNew` will eventually replace the current `GetPosition`. It differs from `GetPosition` in two of its return parameters:

- Instead of returning a `PoseInFrame` it now returns a `Pose`
- There is an additional string return (`component_reference`) that represents the component that should be used to connect the SLAM outputs to RDK's proprioceptive reference frame system.

JIRA Ticket: [RSDK-1073](https://viam.atlassian.net/browse/RSDK-1073)

Note: Tested using dev branch in cartographer integration tests. Will add tests in once the dev parameter PR is submitted and we are ready to start testing endpoints.

[RSDK-1073]: https://viam.atlassian.net/browse/RSDK-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ