### PR TITLE
RSDK-1061 [orb] GetPositionNew

### DIFF
--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -8,7 +8,9 @@ bufsetup:
 	ln -sf `which grpc_cpp_plugin` grpc/bin/protoc-gen-grpc-cpp
 	pkg-config openssl || export PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:`find \`which brew > /dev/null && brew --prefix\` -name openssl.pc | head -n1 | xargs dirname`
 
-buf: bufsetup
+buf: bufsetup bufcompile
+
+bufcompile:
 	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/viamrobotics/api
 	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.grpc.gen.yaml buf.build/viamrobotics/api
 	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/googleapis/googleapis

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -79,7 +79,7 @@ std::atomic<bool> b_continue_session{true};
         currPose = poseGrpc;
     }
 
-    PoseInFrame *responsePose = response->mutable_pose();
+    Pose *responsePose = response->mutable_pose();
     const auto actualPose = currPose.params();
 
     // set pose for our response

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -30,6 +30,10 @@ class SLAMServiceImpl final : public SLAMService::Service {
                                const GetPositionRequest *request,
                                GetPositionResponse *response) override;
 
+    ::grpc::Status GetPositionNew(ServerContext *context,
+                                  const GetPositionNewRequest *request,
+                                  GetPositionNewResponse *response) override;
+
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -14,10 +14,10 @@
 using grpc::ServerContext;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
-using viam::service::slam::v1::GetPositionRequest;
-using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
+using viam::service::slam::v1::GetPositionRequest;
+using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -16,6 +16,8 @@ using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
+using viam::service::slam::v1::GetPositionNewRequest;
+using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1061)

Implements viam.service.slam.v1.SLAMService/GetPositionNew on orbslamv3 slam library.

How to see the output:
```bash
grpcurl -d '{"name": "slam"}'  -plaintext -protoset <(~/slam-clone/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep orb_grpc_serv | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetPositionNew
{
  "pose": {
    "x": 0.007205881178379059,
    "y": -0.004640873987227678,
    "z": 0.021260758861899376
  },
  "componentReference": "color",
  "extra": {
      "quat": {
            "imag": 0.009775514714419842,
            "jmag": 0.006308149080723524,
            "kmag": -0.010251480154693127,
            "real": 0.999879777431488
          }
    }
}
```