### PR TITLE
RSDK-1075 [carto] Add GetInternalState

### DIFF
--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -14,10 +14,7 @@
 
 namespace viam {
 namespace mapping {
-
-using cartographer::mapping::proto::SerializedData;
-
-using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
+    
 const SensorId kRangeSensorId{SensorId::SensorType::RANGE, "range"};
 const SensorId kIMUSensorId{SensorId::SensorType::IMU, "imu"};
 

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -15,11 +15,12 @@
 namespace viam {
 namespace mapping {
 
-using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
 using cartographer::mapping::proto::SerializedData;
 
+using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
 const SensorId kRangeSensorId{SensorId::SensorType::RANGE, "range"};
 const SensorId kIMUSensorId{SensorId::SensorType::IMU, "imu"};
+
 double kDuration = 4.;  // Seconds.
 
 std::vector<::cartographer::transform::Rigid3d>
@@ -84,7 +85,7 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
 
 std::string MapBuilder::SaveMapToStream() {
     std::string buf;
-    const std::string filename = "temp-SaveLoadState.pbstream";
+    const std::string filename = "temp-SaveState.pbstream";
     cartographer::io::ProtoStreamWriter writer(filename);
     map_builder_->SerializeState(/*include_unfinished_submaps=*/false, &writer);
 

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -1,6 +1,8 @@
 // This is an experimental integration of cartographer into RDK.
 #include "cartographer/mapping/map_builder.h"
 
+#include <sstream>
+
 #include "../io/file_handler.h"
 #include "cartographer/common/configuration_file_resolver.h"
 #include "cartographer/common/lua_parameter_dictionary.h"
@@ -11,7 +13,6 @@
 #include "cartographer/mapping/trajectory_builder_interface.h"
 #include "glog/logging.h"
 #include "map_builder.h"
-#include <sstream>
 
 namespace viam {
 namespace mapping {
@@ -83,13 +84,15 @@ bool MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
     return ok;
 }
 
-std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffer) {
+std::string MapBuilder::SaveMapToStream(std::string filename,
+                                        std::string* buffer) {
     std::stringstream error_forwarded;
-    
+
     std::ifstream tempFile(filename);
     if (tempFile.bad()) {
-        error_forwarded << "Failed to open " << filename << " as ifstream object.";
-        error_forwarded << TryFileClose(tempFile,filename);
+        error_forwarded << "Failed to open " << filename
+                        << " as ifstream object.";
+        error_forwarded << TryFileClose(tempFile, filename);
         return error_forwarded.str();
     }
 
@@ -97,7 +100,8 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
     if (bufferStream << tempFile.rdbuf()) {
         *buffer = bufferStream.str();
     } else {
-        error_forwarded << "Failed to get data from " << filename << " to buffer stream.";
+        error_forwarded << "Failed to get data from " << filename
+                        << " to buffer stream.";
         error_forwarded << TryFileClose(tempFile, filename);
         return error_forwarded.str();
     }
@@ -112,7 +116,8 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
     return error_forwarded.str();
 }
 
-std::string MapBuilder::TryFileClose(std::ifstream& tempFile, std::string filename) {
+std::string MapBuilder::TryFileClose(std::ifstream& tempFile,
+                                     std::string filename) {
     tempFile.close();
     if (tempFile.bad()) {
         return (" Failed to close ifstream object " + filename);

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -96,7 +96,8 @@ std::string MapBuilder::SaveMapToStream(const std::string path_to_dir) {
         std::string buffer = bufferStream.str();
         tempFile.close();
     } else {
-        LOG(ERROR) << "Failed to get data from " << filename << " to buffer stream.";
+        LOG(ERROR) << "Failed to get data from " << filename
+                   << " to buffer stream.";
     }
 
     if (std::remove(filename.c_str()) != 0) {

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -83,22 +83,22 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
     }
 }
 
-std::string MapBuilder::SaveMapToStream() {
-    std::string buf;
-    const std::string filename = "temp-SaveState.pbstream";
-    cartographer::io::ProtoStreamWriter writer(filename);
-    map_builder_->SerializeState(/*include_unfinished_submaps=*/false, &writer);
+std::string MapBuilder::SaveMapToStream(const std::string path_to_dir) {
 
-    cartographer::mapping::proto::SerializedData proto;
-    writer.WriteProto(proto);
-    bool ok = proto.SerializeToString(&buf);
-    if (!ok) {
-        LOG(ERROR) << "Serializing the map to buffer failed.";
+    std::string filename = path_to_dir + "/" + "temp.pbstream";
+    SaveMapToFile(false, filename);
+
+    std::ifstream tempFile(filename);
+    std::stringstream bufferStream;
+    bufferStream << tempFile.rdbuf();
+    std::string buffer = bufferStream.str();
+    tempFile.close();
+
+    if (std::remove(filename.c_str()) != 0) {
+        LOG(ERROR) << "Deleting pbstream failed.";
     }
-
-    writer.Close();
-
-    return buf;
+    
+    return buffer;
 }
 
 int MapBuilder::SetTrajectoryBuilder(

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -84,47 +84,6 @@ bool MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
     return ok;
 }
 
-std::string MapBuilder::SaveMapToStream(std::string filename,
-                                        std::string* buffer) {
-    std::stringstream error_forwarded;
-
-    std::ifstream tempFile(filename);
-    if (tempFile.bad()) {
-        error_forwarded << "Failed to open " << filename
-                        << " as ifstream object.";
-        error_forwarded << TryFileClose(tempFile, filename);
-        return error_forwarded.str();
-    }
-
-    std::stringstream bufferStream;
-    if (bufferStream << tempFile.rdbuf()) {
-        *buffer = bufferStream.str();
-    } else {
-        error_forwarded << "Failed to get data from " << filename
-                        << " to buffer stream.";
-        error_forwarded << TryFileClose(tempFile, filename);
-        return error_forwarded.str();
-    }
-
-    error_forwarded << TryFileClose(tempFile, filename);
-
-    if (std::remove(filename.c_str()) != 0) {
-        error_forwarded << "Failed to delete " << filename;
-        return error_forwarded.str();
-    }
-
-    return error_forwarded.str();
-}
-
-std::string MapBuilder::TryFileClose(std::ifstream& tempFile,
-                                     std::string filename) {
-    tempFile.close();
-    if (tempFile.bad()) {
-        return (" Failed to close ifstream object " + filename);
-    }
-    return "";
-}
-
 int MapBuilder::SetTrajectoryBuilder(
     cartographer::mapping::TrajectoryBuilderInterface** trajectory_builder,
     std::set<cartographer::mapping::TrajectoryBuilderInterface::SensorId>

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -89,7 +89,7 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
     std::ifstream tempFile(filename);
     if (tempFile.bad()) {
         error_forwarded << "Failed to open " << filename << " as ifstream object.";
-        TryFileClose(tempFile,filename, &error_forwarded);
+        error_forwarded << TryFileClose(tempFile,filename);
         return error_forwarded.str();
     }
 
@@ -98,11 +98,11 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
         *buffer = bufferStream.str();
     } else {
         error_forwarded << "Failed to get data from " << filename << " to buffer stream.";
-        TryFileClose(tempFile, filename, &error_forwarded);
+        error_forwarded << TryFileClose(tempFile, filename);
         return error_forwarded.str();
     }
 
-    TryFileClose(tempFile, filename, &error_forwarded);
+    error_forwarded << TryFileClose(tempFile, filename);
 
     if (std::remove(filename.c_str()) != 0) {
         error_forwarded << "Failed to delete " << filename;
@@ -112,13 +112,12 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
     return error_forwarded.str();
 }
 
-void MapBuilder::TryFileClose(std::ifstream& tempFile, std::string filename, 
-    std::stringstream* error_forwarded) {
+std::string MapBuilder::TryFileClose(std::ifstream& tempFile, std::string filename) {
     tempFile.close();
     if (tempFile.bad()) {
-        *error_forwarded << " Failed to close ifstream object " << filename;
+        return (" Failed to close ifstream object " + filename);
     }
-    return;
+    return "";
 }
 
 int MapBuilder::SetTrajectoryBuilder(

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -82,17 +82,25 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
 }
 
 std::string MapBuilder::SaveMapToStream(const std::string path_to_dir) {
-    std::string filename = path_to_dir + "/" + "temp.pbstream";
+    std::string filename = path_to_dir + "/" + "temp_internal_state.pbstream";
     SaveMapToFile(false, filename);
 
     std::ifstream tempFile(filename);
+    if (tempFile.bad()) {
+        LOG(ERROR) << "Failed to open " << filename << "as ifstream obejct.";
+    }
+
+    std::string buffer;
     std::stringstream bufferStream;
-    bufferStream << tempFile.rdbuf();
-    std::string buffer = bufferStream.str();
-    tempFile.close();
+    if (bufferStream << tempFile.rdbuf()) {
+        std::string buffer = bufferStream.str();
+        tempFile.close();
+    } else {
+        LOG(ERROR) << "Failed to get data from " << filename << " to buffer stream.";
+    }
 
     if (std::remove(filename.c_str()) != 0) {
-        LOG(ERROR) << "Deleting pbstream failed.";
+        LOG(ERROR) << "Deleting " << filename << " failed.";
     }
 
     return buffer;

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -16,6 +16,7 @@ namespace viam {
 namespace mapping {
 
 using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
+using cartographer::mapping::proto::SerializedData;
 
 const SensorId kRangeSensorId{SensorId::SensorType::RANGE, "range"};
 const SensorId kIMUSensorId{SensorId::SensorType::IMU, "imu"};
@@ -79,6 +80,24 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
     if (!ok) {
         LOG(ERROR) << "Saving the map to pbstream failed.";
     }
+}
+
+std::string MapBuilder::SaveMapToStream() {
+    std::string buf;
+    const std::string filename = "temp-SaveLoadState.pbstream";
+    cartographer::io::ProtoStreamWriter writer(filename);
+    map_builder_->SerializeState(/*include_unfinished_submaps=*/false, &writer);
+
+    cartographer::mapping::proto::SerializedData proto;
+    writer.WriteProto(proto);
+    bool ok = proto.SerializeToString(&buf);
+    if (!ok) {
+        LOG(ERROR) << "Serializing the map to buffer failed.";
+    }
+
+    writer.Close();
+
+    return buf;
 }
 
 int MapBuilder::SetTrajectoryBuilder(

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -85,17 +85,11 @@ bool MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
 
 std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffer) {
     std::stringstream error_forwarded;
-
-    bool ok = map_builder_->SerializeStateToFile(false, filename);
-    if (!ok) {
-       error_forwarded << "Failed to save the state as a pbstream.";
-        return error_forwarded.str();
-    }
     
     std::ifstream tempFile(filename);
     if (tempFile.bad()) {
         error_forwarded << "Failed to open " << filename << " as ifstream object.";
-        TryFileClose(tempFile, &error_forwarded);
+        TryFileClose(tempFile,filename, &error_forwarded);
         return error_forwarded.str();
     }
 
@@ -104,11 +98,11 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
         *buffer = bufferStream.str();
     } else {
         error_forwarded << "Failed to get data from " << filename << " to buffer stream.";
-        TryFileClose(tempFile, &error_forwarded);
+        TryFileClose(tempFile, filename, &error_forwarded);
         return error_forwarded.str();
     }
 
-    TryFileClose(tempFile, &error_forwarded);
+    TryFileClose(tempFile, filename, &error_forwarded);
 
     if (std::remove(filename.c_str()) != 0) {
         error_forwarded << "Failed to delete " << filename;
@@ -118,10 +112,11 @@ std::string MapBuilder::SaveMapToStream(std::string filename, std::string* buffe
     return error_forwarded.str();
 }
 
-void MapBuilder::TryFileClose(std::ifstream& tempFile, std::stringstream* error_forwarded) {
+void MapBuilder::TryFileClose(std::ifstream& tempFile, std::string filename, 
+    std::stringstream* error_forwarded) {
     tempFile.close();
     if (tempFile.bad()) {
-        *error_forwarded << " File closed failed.";
+        *error_forwarded << " Failed to close ifstream object " << filename;
     }
     return;
 }

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -14,7 +14,9 @@
 
 namespace viam {
 namespace mapping {
+
 using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
+
 const SensorId kRangeSensorId{SensorId::SensorType::RANGE, "range"};
 const SensorId kIMUSensorId{SensorId::SensorType::IMU, "imu"};
 double kDuration = 4.;  // Seconds.

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.cc
@@ -14,10 +14,9 @@
 
 namespace viam {
 namespace mapping {
-    
+using SensorId = cartographer::mapping::TrajectoryBuilderInterface::SensorId;
 const SensorId kRangeSensorId{SensorId::SensorType::RANGE, "range"};
 const SensorId kIMUSensorId{SensorId::SensorType::IMU, "imu"};
-
 double kDuration = 4.;  // Seconds.
 
 std::vector<::cartographer::transform::Rigid3d>
@@ -81,7 +80,6 @@ void MapBuilder::SaveMapToFile(bool include_unfinished_submaps,
 }
 
 std::string MapBuilder::SaveMapToStream(const std::string path_to_dir) {
-
     std::string filename = path_to_dir + "/" + "temp.pbstream";
     SaveMapToFile(false, filename);
 
@@ -94,7 +92,7 @@ std::string MapBuilder::SaveMapToStream(const std::string path_to_dir) {
     if (std::remove(filename.c_str()) != 0) {
         LOG(ERROR) << "Deleting pbstream failed.";
     }
-    
+
     return buffer;
 }
 

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -48,8 +48,7 @@ class MapBuilder {
 
     // TryFileClose attempts to close an opened ifstream, returning an error string
     // if it fails.
-    void TryFileClose(std::ifstream& file, std::string filename, 
-                        std::stringstream* error_forwarded);
+    std::string TryFileClose(std::ifstream& file, std::string filename);
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the
     // active trajectory_id.

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -15,6 +15,7 @@
 #include "cartographer/sensor/internal/voxel_filter.h"
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
+#include "cartographer/io/internal/mapping_state_serialization.h"
 
 namespace viam {
 namespace mapping {
@@ -43,7 +44,7 @@ class MapBuilder {
 
     // SaveMapToStream saves the current map_builder_ state to the pbstream
     // stream provided.
-    std::string SaveMapToStream();
+    std::string SaveMapToStream(const std::string filename_with_timestamp);
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the
     // active trajectory_id.

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -41,9 +41,8 @@ class MapBuilder {
     bool SaveMapToFile(bool include_unfinished_submaps,
                        const std::string filename_with_timestamp);
 
-    // SaveMapToStream saves the current map_builder_ state to the pbstream
-    // stream provided via a temporary pbstream file.
-    std::string SaveMapToStream(const std::string filename_with_timestamp,
+    // SaveMapToStream converted the saved pbstream to a stream and deletes the file.
+    std::string ConvertSavedMapToStream(const std::string filename_with_timestamp,
                                 std::string* buffer);
 
     // TryFileClose attempts to close an opened ifstream, returning an error

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -38,12 +38,17 @@ class MapBuilder {
 
     // SaveMapToFile saves the current map_builder_ state to a pbstream file at
     // the provided path.
-    void SaveMapToFile(bool include_unfinished_submaps,
+    bool SaveMapToFile(bool include_unfinished_submaps,
                        const std::string filename_with_timestamp);
 
     // SaveMapToStream saves the current map_builder_ state to the pbstream
-    // stream provided.
-    std::string SaveMapToStream(const std::string filename_with_timestamp);
+    // stream provided via a temporary pbstream file.
+    std::string SaveMapToStream(const std::string filename_with_timestamp, 
+                        std::string* buffer);
+
+    // TryFileClose attempts to close an opened ifstream, returning an error string
+    // if it fails.
+    void TryFileClose(std::ifstream& file, std::stringstream* error_forwarded);
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the
     // active trajectory_id.

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -43,11 +43,11 @@ class MapBuilder {
 
     // SaveMapToStream saves the current map_builder_ state to the pbstream
     // stream provided via a temporary pbstream file.
-    std::string SaveMapToStream(const std::string filename_with_timestamp, 
-                        std::string* buffer);
+    std::string SaveMapToStream(const std::string filename_with_timestamp,
+                                std::string* buffer);
 
-    // TryFileClose attempts to close an opened ifstream, returning an error string
-    // if it fails.
+    // TryFileClose attempts to close an opened ifstream, returning an error
+    // string if it fails.
     std::string TryFileClose(std::ifstream& file, std::string filename);
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -41,9 +41,10 @@ class MapBuilder {
     bool SaveMapToFile(bool include_unfinished_submaps,
                        const std::string filename_with_timestamp);
 
-    // SaveMapToStream converted the saved pbstream to a stream and deletes the file.
-    std::string ConvertSavedMapToStream(const std::string filename_with_timestamp,
-                                std::string* buffer);
+    // SaveMapToStream converted the saved pbstream to a stream and deletes the
+    // file.
+    std::string ConvertSavedMapToStream(
+        const std::string filename_with_timestamp, std::string* buffer);
 
     // TryFileClose attempts to close an opened ifstream, returning an error
     // string if it fails.

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -41,6 +41,10 @@ class MapBuilder {
     void SaveMapToFile(bool include_unfinished_submaps,
                        const std::string filename_with_timestamp);
 
+    // SaveMapToStream saves the current map_builder_ state to the pbstream stream
+    // provided.
+    std::string SaveMapToStream();
+
     // SetTrajectoryBuilder sets the trajectory builder options and returns the
     // active trajectory_id.
     int SetTrajectoryBuilder(

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -15,7 +15,6 @@
 #include "cartographer/sensor/internal/voxel_filter.h"
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
-#include "cartographer/io/internal/mapping_state_serialization.h"
 
 namespace viam {
 namespace mapping {

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -41,8 +41,8 @@ class MapBuilder {
     void SaveMapToFile(bool include_unfinished_submaps,
                        const std::string filename_with_timestamp);
 
-    // SaveMapToStream saves the current map_builder_ state to the pbstream stream
-    // provided.
+    // SaveMapToStream saves the current map_builder_ state to the pbstream
+    // stream provided.
     std::string SaveMapToStream();
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the

--- a/slam-libraries/viam-cartographer/src/mapping/map_builder.h
+++ b/slam-libraries/viam-cartographer/src/mapping/map_builder.h
@@ -48,7 +48,8 @@ class MapBuilder {
 
     // TryFileClose attempts to close an opened ifstream, returning an error string
     // if it fails.
-    void TryFileClose(std::ifstream& file, std::stringstream* error_forwarded);
+    void TryFileClose(std::ifstream& file, std::string filename, 
+                        std::stringstream* error_forwarded);
 
     // SetTrajectoryBuilder sets the trajectory builder options and returns the
     // active trajectory_id.

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -198,8 +198,12 @@ std::atomic<bool> b_continue_session{true};
 ::grpc::Status SLAMServiceImpl::GetInternalState(
     ServerContext *context, const GetInternalStateRequest *request,
     GetInternalStateResponse *response) {
-    std::string buf = map_builder.SaveMapToStream();
-    return grpc::Status::OK;
+    {
+        std::lock_guard<std::mutex> lk(map_builder_mutex);
+        std::string buf = map_builder.SaveMapToStream(path_to_map);        
+        response->set_internal_state(buf);
+        return grpc::Status::OK;
+        }
 }
 
 void SLAMServiceImpl::BackupLatestMap() {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -1,6 +1,9 @@
 // This is an experimental integration of cartographer into RDK.
 #include "slam_service.h"
 
+#include <boost/uuid/uuid.hpp>             // uuid class
+#include <boost/uuid/uuid_generators.hpp>  // generators
+#include <boost/uuid/uuid_io.hpp>
 #include <iostream>
 #include <string>
 
@@ -14,10 +17,6 @@
 #include "cartographer/mapping/id.h"
 #include "cartographer/mapping/map_builder.h"
 #include "glog/logging.h"
-
-#include <boost/uuid/uuid.hpp>            // uuid class
-#include <boost/uuid/uuid_generators.hpp> // generators
-#include <boost/uuid/uuid_io.hpp>
 
 namespace viam {
 
@@ -201,10 +200,9 @@ std::atomic<bool> b_continue_session{true};
 ::grpc::Status SLAMServiceImpl::GetInternalState(
     ServerContext *context, const GetInternalStateRequest *request,
     GetInternalStateResponse *response) {
-
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    std::string filename = path_to_map + "/" + "temp_internal_state_" + 
-        boost::uuids::to_string(uuid) + ".pbstream";
+    std::string filename = path_to_map + "/" + "temp_internal_state_" +
+                           boost::uuids::to_string(uuid) + ".pbstream";
 
     {
         std::lock_guard<std::mutex> lk(map_builder_mutex);
@@ -221,7 +219,7 @@ std::atomic<bool> b_continue_session{true};
 
     if (err != "") {
         std::ostringstream oss;
-            oss << "error during data serialization: " << err;
+        oss << "error during data serialization: " << err;
         return grpc::Status(grpc::StatusCode::UNAVAILABLE, oss.str());
     }
 

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -200,10 +200,10 @@ std::atomic<bool> b_continue_session{true};
     GetInternalStateResponse *response) {
     {
         std::lock_guard<std::mutex> lk(map_builder_mutex);
-        std::string buf = map_builder.SaveMapToStream(path_to_map);        
+        std::string buf = map_builder.SaveMapToStream(path_to_map);
         response->set_internal_state(buf);
         return grpc::Status::OK;
-        }
+    }
 }
 
 void SLAMServiceImpl::BackupLatestMap() {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -13,6 +13,7 @@
 #include "cartographer/io/submap_painter.h"
 #include "cartographer/mapping/id.h"
 #include "cartographer/mapping/map_builder.h"
+#include "cartographer/io/proto_stream.h"
 #include "glog/logging.h"
 
 namespace viam {
@@ -196,28 +197,28 @@ std::atomic<bool> b_continue_session{true};
 
 ::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
     const GetInternalStateRequest *request, GetInternalStateResponse *response) {
-//     // Step 1: Get writer
-//     io::ForwardingProtoStreamWriter writer(
-//       [&chunks](const google::protobuf::Message* proto) -> bool {
-//         if (!proto) {
-//           return true;
-//         }
-//         std::unique_ptr<google::protobuf::Message> p(proto->New());
-//         p->CopyFrom(*proto);
-//         chunks.push(std::move(p));
-//         return true;
-//     });
+    // Step 1: Get writer
+    // cartographer::io::ForwardingProtoStreamWriter writer(
+    //   [&chunks](const google::protobuf::Message* proto) -> bool {
+    //     if (!proto) {
+    //       return true;
+    //     }
+    //     std::unique_ptr<google::protobuf::Message> p(proto->New());
+    //     p->CopyFrom(*proto);
+    //     chunks.push(std::move(p));
+    //     return true;
+    // });
+    
+    // const std::string filename = "temp-SaveLoadState.pbstream";
+    // cartographer::io::ProtoStreamWriter writer(filename);
 
-//     // Step 2: Serialize State
-//     const std::string filename = "temp-LocalizationOnFrozenTrajectory2D.pbstream";
-//     io::ProtoStreamWriter writer(filename);
-//     map_builder->SerializeState(false, %writer); // WritePbStream
-//     if (!ok) {
-//         LOG(ERROR) << "Serializing the internal state failed.";
-//     }
-
-//     // Step 3: Convert writer to bytes
-//     response->internal_state(writer)
+    // Step 3: Convert writer to bytes
+    // SerializedData
+    // std::string buf;
+    std::string buf = map_builder.SaveMapToStream();
+    // std::string buf;
+    // writer->Write(&buf)
+    //response->internal_state(buf)
 
     return grpc::Status::OK;
 }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -197,29 +197,8 @@ std::atomic<bool> b_continue_session{true};
 
 ::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
     const GetInternalStateRequest *request, GetInternalStateResponse *response) {
-    // Step 1: Get writer
-    // cartographer::io::ForwardingProtoStreamWriter writer(
-    //   [&chunks](const google::protobuf::Message* proto) -> bool {
-    //     if (!proto) {
-    //       return true;
-    //     }
-    //     std::unique_ptr<google::protobuf::Message> p(proto->New());
-    //     p->CopyFrom(*proto);
-    //     chunks.push(std::move(p));
-    //     return true;
-    // });
-    
-    // const std::string filename = "temp-SaveLoadState.pbstream";
-    // cartographer::io::ProtoStreamWriter writer(filename);
 
-    // Step 3: Convert writer to bytes
-    // SerializedData
-    // std::string buf;
     std::string buf = map_builder.SaveMapToStream();
-    // std::string buf;
-    // writer->Write(&buf)
-    //response->internal_state(buf)
-
     return grpc::Status::OK;
 }
 

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -10,10 +10,10 @@
 #include "../utils/slam_service_helpers.h"
 #include "cartographer/io/file_writer.h"
 #include "cartographer/io/image.h"
+#include "cartographer/io/proto_stream.h"
 #include "cartographer/io/submap_painter.h"
 #include "cartographer/mapping/id.h"
 #include "cartographer/mapping/map_builder.h"
-#include "cartographer/io/proto_stream.h"
 #include "glog/logging.h"
 
 namespace viam {
@@ -195,9 +195,9 @@ std::atomic<bool> b_continue_session{true};
     }
 }
 
-::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
-    const GetInternalStateRequest *request, GetInternalStateResponse *response) {
-
+::grpc::Status SLAMServiceImpl::GetInternalState(
+    ServerContext *context, const GetInternalStateRequest *request,
+    GetInternalStateResponse *response) {
     std::string buf = map_builder.SaveMapToStream();
     return grpc::Status::OK;
 }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -215,7 +215,7 @@ std::atomic<bool> b_continue_session{true};
     }
 
     std::string buf;
-    try  {
+    try {
         ConvertSavedMapToStream(filename, &buf);
         response->set_internal_state(buf);
     } catch (std::exception &e) {
@@ -223,10 +223,11 @@ std::atomic<bool> b_continue_session{true};
         oss << "error during data serialization: " << e.what();
         return grpc::Status(grpc::StatusCode::UNAVAILABLE, oss.str());
     }
+    return grpc::Status::OK;
 }
 
 void SLAMServiceImpl::ConvertSavedMapToStream(std::string filename,
-                                        std::string* buffer) {
+                                              std::string *buffer) {
     std::stringstream error_forwarded;
 
     std::ifstream tempFile(filename);
@@ -234,7 +235,7 @@ void SLAMServiceImpl::ConvertSavedMapToStream(std::string filename,
         error_forwarded << "Failed to open " << filename
                         << " as ifstream object.";
         error_forwarded << TryFileClose(tempFile, filename);
-         throw std::runtime_error(error_forwarded.str());
+        throw std::runtime_error(error_forwarded.str());
     }
 
     std::stringstream bufferStream;
@@ -244,19 +245,19 @@ void SLAMServiceImpl::ConvertSavedMapToStream(std::string filename,
         error_forwarded << "Failed to get data from " << filename
                         << " to buffer stream.";
         error_forwarded << TryFileClose(tempFile, filename);
-         throw std::runtime_error(error_forwarded.str());
+        throw std::runtime_error(error_forwarded.str());
     }
 
     error_forwarded << TryFileClose(tempFile, filename);
 
     if (std::remove(filename.c_str()) != 0) {
         error_forwarded << "Failed to delete " << filename;
-         throw std::runtime_error(error_forwarded.str());
+        throw std::runtime_error(error_forwarded.str());
     }
 }
 
-std::string SLAMServiceImpl::TryFileClose(std::ifstream& tempFile,
-                                     std::string filename) {
+std::string SLAMServiceImpl::TryFileClose(std::ifstream &tempFile,
+                                          std::string filename) {
     tempFile.close();
     if (tempFile.bad()) {
         return (" Failed to close ifstream object " + filename);

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -197,12 +197,11 @@ std::atomic<bool> b_continue_session{true};
 ::grpc::Status SLAMServiceImpl::GetInternalState(
     ServerContext *context, const GetInternalStateRequest *request,
     GetInternalStateResponse *response) {
-    {
-        std::lock_guard<std::mutex> lk(map_builder_mutex);
-        std::string buf = map_builder.SaveMapToStream(path_to_map);
-        response->set_internal_state(buf);
-        return grpc::Status::OK;
-    }
+    
+    std::string buf = map_builder.SaveMapToStream(path_to_map);
+    response->set_internal_state(buf);
+    return grpc::Status::OK;
+
 }
 
 void SLAMServiceImpl::BackupLatestMap() {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -194,6 +194,34 @@ std::atomic<bool> b_continue_session{true};
     }
 }
 
+::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
+    const GetInternalStateRequest *request, GetInternalStateResponse *response) {
+//     // Step 1: Get writer
+//     io::ForwardingProtoStreamWriter writer(
+//       [&chunks](const google::protobuf::Message* proto) -> bool {
+//         if (!proto) {
+//           return true;
+//         }
+//         std::unique_ptr<google::protobuf::Message> p(proto->New());
+//         p->CopyFrom(*proto);
+//         chunks.push(std::move(p));
+//         return true;
+//     });
+
+//     // Step 2: Serialize State
+//     const std::string filename = "temp-LocalizationOnFrozenTrajectory2D.pbstream";
+//     io::ProtoStreamWriter writer(filename);
+//     map_builder->SerializeState(false, %writer); // WritePbStream
+//     if (!ok) {
+//         LOG(ERROR) << "Serializing the internal state failed.";
+//     }
+
+//     // Step 3: Convert writer to bytes
+//     response->internal_state(writer)
+
+    return grpc::Status::OK;
+}
+
 void SLAMServiceImpl::BackupLatestMap() {
     std::string jpeg_map_with_marker_tmp = GetLatestJpegMapString(true);
     std::string jpeg_map_without_marker_tmp = GetLatestJpegMapString(false);

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -197,11 +197,9 @@ std::atomic<bool> b_continue_session{true};
 ::grpc::Status SLAMServiceImpl::GetInternalState(
     ServerContext *context, const GetInternalStateRequest *request,
     GetInternalStateResponse *response) {
-    
     std::string buf = map_builder.SaveMapToStream(path_to_map);
     response->set_internal_state(buf);
     return grpc::Status::OK;
-
 }
 
 void SLAMServiceImpl::BackupLatestMap() {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -10,7 +10,6 @@
 #include "../utils/slam_service_helpers.h"
 #include "cartographer/io/file_writer.h"
 #include "cartographer/io/image.h"
-#include "cartographer/io/proto_stream.h"
 #include "cartographer/io/submap_painter.h"
 #include "cartographer/mapping/id.h"
 #include "cartographer/mapping/map_builder.h"

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -209,6 +209,11 @@ std::atomic<bool> b_continue_session{true};
     {
         std::lock_guard<std::mutex> lk(map_builder_mutex);
         bool ok = map_builder.SaveMapToFile(true, filename);
+        if (!ok) {
+            std::ostringstream oss;
+            oss << "Failed to save the state as a pbstream.";
+            return grpc::Status(grpc::StatusCode::UNAVAILABLE, oss.str());
+        }
     }
 
     std::string buf;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -25,14 +25,14 @@ using grpc::ServerContext;
 using viam::common::v1::PointCloudObject;
 using viam::common::v1::Pose;
 using viam::common::v1::PoseInFrame;
+using viam::service::slam::v1::GetInternalStateRequest;
+using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
 using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
-using viam::service::slam::v1::GetInternalStateRequest;
-using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {
@@ -65,11 +65,11 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 
-    // GetInternalState returns the current internal state of the map which is 
+    // GetInternalState returns the current internal state of the map which is
     // a pbstream for cartographer.
-    ::grpc::Status GetInternalState(ServerContext *context, 
-                                const GetInternalStateRequest *request,
-                                GetInternalStateResponse *response) override;
+    ::grpc::Status GetInternalState(
+        ServerContext *context, const GetInternalStateRequest *request,
+        GetInternalStateResponse *response) override;
 
     // RunSLAM sets up and runs cartographer. It runs cartographer in
     // the ActionMode mode: Either creating

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -167,6 +167,15 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // timestamp of the time when the map is saved.
     void SaveMapWithTimestamp();
 
+    // ConvertSavedMapToStream converted the saved pbstream to a stream and deletes 
+    // the file.
+    void ConvertSavedMapToStream(const std::string filename_with_timestamp,
+                                std::string* buffer);
+
+    // TryFileClose attempts to close an opened ifstream, returning an error
+    // string if it fails.
+    std::string TryFileClose(std::ifstream& file, std::string filename);
+
     // GetJpegMap paints the jpeg version of the map and writes the
     // image to the response. Returns a grpc status that reflects
     // whether or not painting the map and writing it to the response

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -167,14 +167,14 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // timestamp of the time when the map is saved.
     void SaveMapWithTimestamp();
 
-    // ConvertSavedMapToStream converted the saved pbstream to a stream and deletes 
-    // the file.
+    // ConvertSavedMapToStream converted the saved pbstream to the passed in
+    // string and deletes the file.
     void ConvertSavedMapToStream(const std::string filename_with_timestamp,
-                                std::string* buffer);
+                                 std::string *buffer);
 
     // TryFileClose attempts to close an opened ifstream, returning an error
     // string if it fails.
-    std::string TryFileClose(std::ifstream& file, std::string filename);
+    std::string TryFileClose(std::ifstream &file, std::string filename);
 
     // GetJpegMap paints the jpeg version of the map and writes the
     // image to the response. Returns a grpc status that reflects

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -31,6 +31,8 @@ using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
+using viam::service::slam::v1::GetInternalStateRequest;
+using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {
@@ -63,7 +65,13 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 
-    // RunSLAM sets up and runs cartographer. It runs cartogapher in
+    // GetInternalState returns the current internal state of the map which is 
+    // a pbstream for cartographer.
+    ::grpc::Status GetInternalState(ServerContext *context, 
+                                const GetInternalStateRequest *request,
+                                GetInternalStateResponse *response) override;
+
+    // RunSLAM sets up and runs cartographer. It runs cartographer in
     // the ActionMode mode: Either creating
     // a new map, updating an apriori map, or localizing on an apriori map.
     void RunSLAM();


### PR DESCRIPTION
This PR allows for the on-demand serialization of the internal state (.pbstream) of cartographer. This can then be saved to a file and loaded into a subsequent cartographer run. Currently addition PRs are in the work to do this for OrbSLAM, adding the GetInternalState endpoint to RDK and including GetInternalState tests to the integration testing scripts.


JIRA Ticket: [RSDK-1075](https://viam.atlassian.net/browse/RSDK-1075)

RDK PR/ Cartographer Testing (adding GetInternalState): [PR #1776](https://github.com/viamrobotics/rdk/pull/1776)


Notes:
The implementation in this PR utilizes a file interface to access the data and sent it over grpc to RDK. This is no ideal as it contains a file read and write. However, this is hard to get away from which I found after about 6 hours of research. 

Cartographer has two functions for serializing the state `SerializeState` and `SerializeStateToFile`. However this is no entirely true as `SerializeState` performs the exact same function as `SerializeStateToFile` except it requires the user to define  a `ProtoStreamWriter`. normally you'd think that we could then use this data object to access the serialized data and prevent it being added to a file. 

However, due to the strict type definition of `ProtoStreamWriter`, we not only cannot access the data directly, but it is stored in an `ofstream` which means it will write any data added to it directly to the filename set upon its definition. The only possible solutions to this is to either:

- Attempt to copy over half of `mapping/io/internal` along with `proto_stream.h/.cc` and `proto_stream_interface.h` to allow a viam version to be created and then relink these files. (2-3d)
- Edit cartographer itself which we have avoided doing up until now (1d)
- Manually serialize each part of state which will involves lots of copying and relinked (1-2d).

For now, I've gone with the much simpler file interface method and deleteing the produced temp file. If we wish to pursue others we should discuss whether that be done now or later. Additionally, if anyone wants to run though the logic with me feel free to PM me directly. 

Testing:
This PR was tested on both the integration test data set as well as the large 5MB office dataset without issues. To replicate said testing you can follow the instructions below:

1. Install grpcurl (go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest) and jq (sudo apt-get install jq) 

2. Start RDK server with either live data or an appropriate offline dataset

3. Run agrpcurl current request of the GetInternalState endpoint `grpcurl -max-msg-sz 10000000 -d '{"name": "slam"}' -plaintext -protoset <(~/slam/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep carto_grpc_ | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetInternalState >> ~/output_raw.pbstream`
Note: You may need to edit the grep part of the command due to it being cut off

4. Transform the output into base64 using jq `cat ~/output_raw.pbstream | jq -r ".internalState" | base64 -d >> ~/output.pbstream`

5. Move `~/output.pbstream` into your data folder and rename it to a valid map name/timestamp (Note: if you are running on offline data you should also make sure the timestamp for this file is before the last of your data files)

6. Re run RDK server and confirm that cartographer starts processing data without issue. If an issue occurs it will cause constant restarts of the binary



[RSDK-1075]: https://viam.atlassian.net/browse/RSDK-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ