### PR TITLE
[RSDK-1062] implement orb GetPointCloudMap

### DIFF
--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -140,8 +140,10 @@ iterates throught all the bytes of the float
 writes each byte to buffer 
 */
 void writeFloatToBufferInBytes(std::string buffer, float f) {
+    BOOST_LOG_TRIVIAL(debug) << "writing float: " << f << "\nsize of float: " << sizeof(float);
     unsigned char const * const p = (unsigned char const *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
+        BOOST_LOG_TRIVIAL(debug) << "index " << i << " as integer: " << p[i] << "\n";
         buffer.push_back(p[i]);
     }
 }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -116,11 +116,9 @@ std::atomic<bool> b_continue_session{true};
     float max = 0;
     float min = 10000;
     std::vector<ORB_SLAM3::MapPoint *> actualMap;
-    Sophus::SE3f currPose;
     {
         std::lock_guard<std::mutex> lk(slam_mutex);
         actualMap = currMapPoints;
-        currPose = poseGrpc;
     }
 
     if (actualMap.size() == 0) {

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -39,7 +39,6 @@ const auto HEADERTEMPLATE =
     "POINTS %d\n"
     "DATA binary\n";
 
-
 std::atomic<bool> b_continue_session{true};
 
 ::grpc::Status SLAMServiceImpl::GetPosition(ServerContext *context,

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -140,7 +140,7 @@ iterates throught all the bytes of the float
 writes each byte to buffer 
 */
 void writeFloatToBufferInBytes(std::string* buffer, float f) {
-    const char * const p = (const char *)(&f);
+    unsigned const char * const p = (unsigned const char *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
         buffer->push_back(p[i]);
     }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -136,12 +136,24 @@ std::string pcdHeader(int mapSize) {
 
 /*
 casts the float f to a pointer of unsigned bytes
-iterates throught all the bytes of the float
+iterates throught all the bytes of f
 writes each byte to buffer 
 */
 void writeFloatToBufferInBytes(std::string* buffer, float f) {
     unsigned const char * const p = (unsigned const char *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
+        buffer->push_back(p[i]);
+    }
+}
+
+/*
+casts the uint32_t f to a pointer of unsigned bytes
+iterates throught all the bytes of f
+writes each byte to buffer 
+*/
+void writeIntUnsignedToBufferInBytes(std::string* buffer, uint32_t f) {
+    unsigned const char * const p = (unsigned const char *)(&f);
+    for (std::size_t i = 0; i < sizeof(uint32_t); ++i) {
         buffer->push_back(p[i]);
     }
 }
@@ -198,7 +210,7 @@ void writeFloatToBufferInBytes(std::string* buffer, float f) {
         cv::cvtColor(hsv, valRGB2, cv::COLOR_HSV2RGB);
         cv::Vec3b colorRGB = valRGB2.at<cv::Vec3b>(cv::Point(0, 0));
 
-        int rgb = 0;
+        uint32_t rgb = 0;
         rgb = rgb | ((int)colorRGB[0] << 16);
         rgb = rgb | ((int)colorRGB[1] << 8);
         rgb = rgb | ((int)colorRGB[2] << 0);
@@ -206,7 +218,7 @@ void writeFloatToBufferInBytes(std::string* buffer, float f) {
         writeFloatToBufferInBytes(&buffer, v.x());
         writeFloatToBufferInBytes(&buffer, v.y());
         writeFloatToBufferInBytes(&buffer, v.z());
-        writeFloatToBufferInBytes(&buffer, rgb);
+        writeIntUnsignedToBufferInBytes(&buffer, rgb);
     }
     response->set_point_cloud_pcd(buffer);
     return grpc::Status::OK;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <cfenv>
-#include <cstdint>
 #define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
@@ -56,7 +55,7 @@ iterates throught all the 8 bit bytes of f
 writes each 8 bit bytes to buffer
 */
 void writeFloatToBufferInBytes(std::string &buffer, float f) {
-    auto p = (const uint8_t *)(&f);
+    auto p = (const char *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
         buffer.push_back(p[i]);
     }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -1,8 +1,9 @@
 // This is an experimental integration of orbslam into RDK.
 #include "orbslam_server_v1.h"
-#include <cstdint>
+
 #include <algorithm>
 #include <cfenv>
+#include <cstdint>
 #define BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
@@ -55,7 +56,7 @@ iterates throught all the 8 bit bytes of f
 writes each 8 bit bytes to buffer
 */
 void writeFloatToBufferInBytes(std::string &buffer, float f) {
-    auto p = (const uint8_t*)(&f);
+    auto p = (const uint8_t *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
         buffer.push_back(p[i]);
     }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -25,13 +25,13 @@ using viam::common::v1::PoseInFrame;
 const std::string strRGB = "/rgb";
 const std::string strDepth = "/depth";
 const std::string HEADERTEMPLATE = "VERSION .7\n"
-                                   "FIELDS x y z rgb\n"
+                                   "FIELDS x y z\n"
                                    // NOTE: If a float is more than 4 bytes
                                    // on a given platform
                                    // this size will be inaccurate
-                                   "SIZE 4 4 4 4\n"
-                                   "TYPE F F F I\n"
-                                   "COUNT 1 1 1 1\n"
+                                   "SIZE 4 4 4\n"
+                                   "TYPE F F F\n"
+                                   "COUNT 1 1 1\n"
                                    "WIDTH %d\n"
                                    "HEIGHT 1\n"
                                    "VIEWPOINT 0 0 0 1 0 0 0\n"

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -139,13 +139,10 @@ casts the float f to a pointer of unsigned bytes
 iterates throught all the bytes of the float
 writes each byte to buffer 
 */
-void writeFloatToBufferInBytes(std::string buffer, float f) {
-    BOOST_LOG_TRIVIAL(debug) << boost::format("writing float: %f, size of float: %d\n") % f % sizeof(float);
+void writeFloatToBufferInBytes(std::string* buffer, float f) {
     const char * const p = (const char *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
-        BOOST_LOG_TRIVIAL(debug) << boost::format("index: %i as integer: %d\n") % i % p[i];
-        // buffer.sputn((const char *)&v.z(), 4);
-        buffer.push_back(p[i]);
+        buffer->push_back(p[i]);
     }
 }
 
@@ -206,10 +203,10 @@ void writeFloatToBufferInBytes(std::string buffer, float f) {
         rgb = rgb | ((int)colorRGB[1] << 8);
         rgb = rgb | ((int)colorRGB[2] << 0);
 
-        writeFloatToBufferInBytes(buffer, v.x());
-        writeFloatToBufferInBytes(buffer, v.y());
-        writeFloatToBufferInBytes(buffer, v.z());
-        writeFloatToBufferInBytes(buffer, rgb);
+        writeFloatToBufferInBytes(&buffer, v.x());
+        writeFloatToBufferInBytes(&buffer, v.y());
+        writeFloatToBufferInBytes(&buffer, v.z());
+        writeFloatToBufferInBytes(&buffer, rgb);
     }
     response->set_point_cloud_pcd(buffer);
     return grpc::Status::OK;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -140,10 +140,11 @@ iterates throught all the bytes of the float
 writes each byte to buffer 
 */
 void writeFloatToBufferInBytes(std::string buffer, float f) {
-    BOOST_LOG_TRIVIAL(debug) << "writing float: " << f << "\nsize of float: " << sizeof(float);
-    unsigned char const * const p = (unsigned char const *)(&f);
+    BOOST_LOG_TRIVIAL(debug) << boost::format("writing float: %f, size of float: %d\n") % f % sizeof(float);
+    const char * const p = (const char *)(&f);
     for (std::size_t i = 0; i < sizeof(float); ++i) {
-        BOOST_LOG_TRIVIAL(debug) << "index " << i << " as integer: " << p[i] << "\n";
+        BOOST_LOG_TRIVIAL(debug) << boost::format("index: %i as integer: %d\n") % i % p[i];
+        // buffer.sputn((const char *)&v.z(), 4);
         buffer.push_back(p[i]);
     }
 }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -41,26 +41,6 @@ const auto HEADERTEMPLATE =
 
 namespace viam {
 
-/*
-applies the mapSize to the HEADERTEMPLATE
-returning the pcd header as a string
-*/
-std::string pcdHeader(int mapSize) {
-    return str(boost::format(HEADERTEMPLATE) % mapSize % mapSize);
-}
-
-/*
-casts the float f to a pointer of unsigned 8 bit bytes
-iterates throught all the 8 bit bytes of f
-writes each 8 bit bytes to buffer
-*/
-void writeFloatToBufferInBytes(std::string &buffer, float f) {
-    auto p = (const char *)(&f);
-    for (std::size_t i = 0; i < sizeof(float); ++i) {
-        buffer.push_back(p[i]);
-    }
-}
-
 std::atomic<bool> b_continue_session{true};
 
 ::grpc::Status SLAMServiceImpl::GetPosition(ServerContext *context,
@@ -160,13 +140,13 @@ std::atomic<bool> b_continue_session{true};
                             "currently no map points exist");
     }
 
-    auto buffer = pcdHeader(actualMap.size());
+    auto buffer = utils::PcdHeader(actualMap.size());
 
     for (auto p : actualMap) {
         Eigen::Matrix<float, 3, 1> v = p->GetWorldPos();
-        writeFloatToBufferInBytes(buffer, v.x());
-        writeFloatToBufferInBytes(buffer, v.y());
-        writeFloatToBufferInBytes(buffer, v.z());
+        utils::WriteFloatToBufferInBytes(buffer, v.x());
+        utils::WriteFloatToBufferInBytes(buffer, v.y());
+        utils::WriteFloatToBufferInBytes(buffer, v.z());
     }
     response->set_point_cloud_pcd(buffer);
     return grpc::Status::OK;
@@ -1041,6 +1021,26 @@ string MakeFilenameWithTimestamp(string path_to_dir, string camera_name) {
                   std::gmtime(&t));
     // Save the current atlas map in *.osa style
     return path_to_dir + "/" + camera_name + "_data_" + timestamp + ".osa";
+}
+
+/*
+applies the mapSize to the HEADERTEMPLATE
+returning the pcd header as a string
+*/
+std::string PcdHeader(int mapSize) {
+    return str(boost::format(HEADERTEMPLATE) % mapSize % mapSize);
+}
+
+/*
+casts the float f to a pointer of unsigned 8 bit bytes
+iterates throught all the 8 bit bytes of f
+writes each 8 bit bytes to buffer
+*/
+void WriteFloatToBufferInBytes(std::string &buffer, float f) {
+    auto p = (const char *)(&f);
+    for (std::size_t i = 0; i < sizeof(float); ++i) {
+        buffer.push_back(p[i]);
+    }
 }
 
 }  // namespace utils

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -14,7 +14,6 @@
 #pragma STDC FENV_ACCESS ON
 
 using namespace boost::filesystem;
-using boost::format;
 using google::protobuf::Struct;
 using viam::common::v1::PointCloudObject;
 using viam::common::v1::Pose;
@@ -24,6 +23,7 @@ using viam::common::v1::PoseInFrame;
 #define MAX_COLOR_VALUE 255
 const std::string strRGB = "/rgb";
 const std::string strDepth = "/depth";
+namespace viam {
 const auto HEADERTEMPLATE =
     "VERSION .7\n"
     "FIELDS x y z\n"
@@ -39,7 +39,6 @@ const auto HEADERTEMPLATE =
     "POINTS %d\n"
     "DATA binary\n";
 
-namespace viam {
 
 std::atomic<bool> b_continue_session{true};
 
@@ -1028,7 +1027,7 @@ applies the mapSize to the HEADERTEMPLATE
 returning the pcd header as a string
 */
 std::string PcdHeader(int mapSize) {
-    return str(boost::format(HEADERTEMPLATE) % mapSize % mapSize);
+    return str(boost::format(viam::HEADERTEMPLATE) % mapSize % mapSize);
 }
 
 /*

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -146,5 +146,10 @@ string MakeFilenameWithTimestamp(string path_to_dir, string camera_name);
 // Removes data file
 void RemoveFile(std::string file_path);
 
+std::string PcdHeader(int mapSize);
+
+void WriteFloatToBufferInBytes(std::string &buffer, float f);
+
+
 }  // namespace utils
 }  // namespace viam

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -14,6 +14,8 @@
 using grpc::ServerContext;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
+using viam::service::slam::v1::GetPointCloudMapRequest;
+using viam::service::slam::v1::GetPointCloudMapResponse;
 using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
@@ -38,6 +40,10 @@ class SLAMServiceImpl final : public SLAMService::Service {
 
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
+
+    ::grpc::Status GetPointCloudMap(
+        ServerContext *context, const GetPointCloudMapRequest *request,
+        GetPointCloudMapResponse *response) override;
 
     void ProcessDataOnline(ORB_SLAM3::System *SLAM);
 

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -150,6 +150,5 @@ std::string PcdHeader(int mapSize);
 
 void WriteFloatToBufferInBytes(std::string &buffer, float f);
 
-
 }  // namespace utils
 }  // namespace viam

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -41,6 +41,15 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 
+    /*
+      For a given GetPointCloudMapRequest
+      Returns a GetPointCloudMapResponse containing a sparse
+      slam map as a Binary PCD file
+
+      Map uses:
+      1. right hand rule
+      2. z axis is in the direction the camera is facing
+    */
     ::grpc::Status GetPointCloudMap(
         ServerContext *context, const GetPointCloudMapRequest *request,
         GetPointCloudMapResponse *response) override;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -44,11 +44,9 @@ class SLAMServiceImpl final : public SLAMService::Service {
     /*
       For a given GetPointCloudMapRequest
       Returns a GetPointCloudMapResponse containing a sparse
-      slam map as a Binary PCD file
+      slam map as Binary PCD
 
-      Map uses:
-      1. right hand rule
-      2. z axis is in the direction the camera is facing
+      Map uses z axis is in the direction the camera is facing
     */
     ::grpc::Status GetPointCloudMap(
         ServerContext *context, const GetPointCloudMapRequest *request,

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -24,6 +24,7 @@ void exit_loop_handler(int s) {
 }
 
 int main(int argc, char **argv) {
+    static_assert(sizeof(float) == 4 && CHAR_BIT == 8, "32 bit float & 8 bit char is assumed");
     // TODO: change inputs to match args from rdk
     // https://viam.atlassian.net/jira/software/c/projects/DATA/boards/30?modal=detail&selectedIssue=DATA-179
     struct sigaction sigHandler;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -24,7 +24,6 @@ void exit_loop_handler(int s) {
 }
 
 int main(int argc, char **argv) {
-    static_assert(sizeof(float) == 4 && CHAR_BIT == 8, "32 bit float & 8 bit char is assumed");
     // TODO: change inputs to match args from rdk
     // https://viam.atlassian.net/jira/software/c/projects/DATA/boards/30?modal=detail&selectedIssue=DATA-179
     struct sigaction sigHandler;


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1062)

Add GetPointCloudMap GRPC endpoint to orbslam.

Tested via:

```bash
# request new endpoint
grpcurl -d '{"name": "run-slam"}'  -plaintext -protoset <(~/slam-clone/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep orb_grpc_se | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetPointCloudMap | jq -r '.pointCloudPcd' | base64 -d > get_point_cloud_map.pcd

# request old endpoint
grpcurl -d '{"name": "run-slam", "mime_type": "pointcloud/pcd"}'  -plaintext -protoset <(~/slam-clone/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep orb_grpc_ | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetMap | jq -r '.pointCloud.pointCloud' | base64 -d > get_map.pcd

#convert new & old response value to ascii for easier analysis
pcl_convert_pcd_ascii_binary get_map.pcd get_map_ascii3.pcd 0
pcl_convert_pcd_ascii_binary get_point_cloud_map.pcd get_point_cloud_map_ascii3.pcd 0

# observe they are the same except for the color
vimdiff get_map_ascii3.pcd get_point_cloud_map_ascii3.pcd
```
[get_point_cloud_map_ascii3.pcd.txt](https://github.com/viamrobotics/slam/files/10520635/get_point_cloud_map_ascii3.pcd.txt)
[get_map_ascii3.pcd.txt](https://github.com/viamrobotics/slam/files/10520641/get_map_ascii3.pcd.txt)


 attached


I also confirmed that app.viam UI is able to render the new returned point cloud:



With the `dev` config feature flag off (i.e. old GetMap endpoint):
![old](https://user-images.githubusercontent.com/5927876/215134770-8f05a7f8-2c64-406b-9561-e0911a98077a.png)

With the `dev` config feature flag on (i.e. old GetPointCloudMap endpoint):
![new](https://user-images.githubusercontent.com/5927876/215134891-810138d6-ec28-4b3f-bd00-515adfac9ee2.png)


