### PR TITLE
[RSDK-1816] update submodules to use http links instead of ssh 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "slam-libraries/viam-cartographer/cartographer"]
 	path = slam-libraries/viam-cartographer/cartographer
-	url = git@github.com:cartographer-project/cartographer.git
+	url = https://github.com/cartographer-project/cartographer.git
 [submodule "slam-libraries/viam-orb-slam3/ORB_SLAM3"]
 	path = slam-libraries/viam-orb-slam3/ORB_SLAM3
-	url = git@github.com:viamrobotics/ORB_SLAM3.git
+	url = https://github.com/viamrobotics/ORB_SLAM3.git


### PR DESCRIPTION
submodule links made the reppo unable to retrieve the submodules unless there was an ssh key in use with github. In addition the ssh links would cause the brew packages to fail on systems without an ssh key.

ticket: https://viam.atlassian.net/browse/RSDK-1816