### PR TITLE
Rsdk 1063 implement orb GetInternalState

### DIFF
--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -425,6 +425,13 @@ std::atomic<bool> b_continue_session{true};
     return grpc::Status::OK;
 }
 
+::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
+                                       const GetInternalStateRequest *request,
+                                       GetInternalStateResponse *response) {
+                                        
+    return grpc::Status::OK;
+}
+
 void SLAMServiceImpl::ProcessDataOnline(ORB_SLAM3::System *SLAM) {
     std::vector<std::string> filesRGB = utils::ListFilesInDirectoryForCamera(
         path_to_data + strRGB, ".png", camera_name);

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -449,7 +449,10 @@ std::atomic<bool> b_continue_session{true};
 // so that the SLAM pointer can never be null.
 // SetSlam only exists so that ArchiveSlam will have access
 // to the SLAM object when called by the GRPC handlers.
-void SLAMServiceImpl::SetSlam(ORB_SLAM3::System *s) { slam = s; }
+void SLAMServiceImpl::SetSlam(ORB_SLAM3::System *s) {
+    std::lock_guard<std::mutex> lk(slam_mutex);
+    slam = s;
+}
 
 bool SLAMServiceImpl::ArchiveSlam(std::stringbuf &buffer) {
     std::lock_guard<std::mutex> lk(slam_mutex);

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -465,7 +465,6 @@ bool SLAMServiceImpl::ArchiveSlam(std::stringbuf &buffer) {
         BOOST_LOG_TRIVIAL(debug) << "ArchiveSlam slam is NULL";
         return false;
     }
-    BOOST_LOG_TRIVIAL(debug) << "ArchiveSlam slam is NOT NULL";
     slam->DumpOsa(buffer);
     return true;
 }

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -440,9 +440,9 @@ std::atomic<bool> b_continue_session{true};
 }
 
 // TODO: This is an antipattern, which only exists b/c:
-// 1. we only have one class for both the data thread(s) 
+// 1. we only have one class for both the data thread(s)
 //    & GRPC server
-// 2. we will hit the RDK timeout if we wait for the SLAM 
+// 2. we will hit the RDK timeout if we wait for the SLAM
 //    algo to fully boot before booting the GRPC server
 // In the future there should be a separate class from the
 // GRPC server, whose constructor initializes the slam object

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.cc
@@ -425,10 +425,9 @@ std::atomic<bool> b_continue_session{true};
     return grpc::Status::OK;
 }
 
-::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
-                                       const GetInternalStateRequest *request,
-                                       GetInternalStateResponse *response) {
-
+::grpc::Status SLAMServiceImpl::GetInternalState(
+    ServerContext *context, const GetInternalStateRequest *request,
+    GetInternalStateResponse *response) {
     std::stringbuf buffer;
     bool success = ArchiveSlam(buffer);
     if (success) {
@@ -444,7 +443,7 @@ std::atomic<bool> b_continue_session{true};
 // which only exists b/c we only have one class
 // for both the data thread(s) & GRPC server & the
 // fact that it takes a while to fully initialize
-// the slam algo (longer than we want to wait to 
+// the slam algo (longer than we want to wait to
 // boot the GRPC server, so as to not hit timeouts
 // in RDK).
 // In the future there should be a class that initializes
@@ -453,9 +452,7 @@ std::atomic<bool> b_continue_session{true};
 // It only exists so that ArchiveSlam (called by the
 // GRPC handlers) can get access to the slam object
 // to call DumpOsa.
-void SLAMServiceImpl::SetSlam(ORB_SLAM3::System* s) {
-    slam = s;
-}
+void SLAMServiceImpl::SetSlam(ORB_SLAM3::System *s) { slam = s; }
 
 bool SLAMServiceImpl::ArchiveSlam(std::stringbuf &buffer) {
     // I belive this is the right place to put this mutex as

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -23,6 +23,7 @@ using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::GetInternalStateRequest;
 using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::SLAMService;
+using SlamPtr = std::unique_ptr<ORB_SLAM3::System>;
 
 namespace viam {
 
@@ -54,7 +55,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerContext *context, const GetPointCloudMapRequest *request,
         GetPointCloudMapResponse *response) override;
 
-    ::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
+   ::grpc::Status GetInternalState(ServerContext *context,
                                        const GetInternalStateRequest *request,
                                        GetInternalStateResponse *response) override;
 
@@ -71,6 +72,10 @@ class SLAMServiceImpl final : public SLAMService::Service {
     void StartSaveAtlasAsOsa(ORB_SLAM3::System *SLAM);
 
     void StopSaveAtlasAsOsa();
+
+    void SetSlam(ORB_SLAM3::System* s);
+    bool ArchiveSlam(std::stringbuf &buffer);
+
 
     string path_to_data;
     string path_to_map;
@@ -94,12 +99,14 @@ class SLAMServiceImpl final : public SLAMService::Service {
     int n_key_frames = 0;
     int curr_map_id = 0;
 
+
    private:
     void SaveAtlasAsOsaWithTimestamp(ORB_SLAM3::System *SLAM);
 
     std::atomic<bool> finished_processing_offline{false};
     std::thread *thread_save_atlas_as_osa_with_timestamp;
 
+    ORB_SLAM3::System* slam;
     std::mutex slam_mutex;
     Sophus::SE3f poseGrpc;
     std::vector<ORB_SLAM3::MapPoint *> currMapPoints;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -20,6 +20,8 @@ using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
+using viam::service::slam::v1::GetInternalStateRequest;
+using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::SLAMService;
 
 namespace viam {
@@ -51,6 +53,10 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetPointCloudMap(
         ServerContext *context, const GetPointCloudMapRequest *request,
         GetPointCloudMapResponse *response) override;
+
+    ::grpc::Status SLAMServiceImpl::GetInternalState(ServerContext *context,
+                                       const GetInternalStateRequest *request,
+                                       GetInternalStateResponse *response) override;
 
     void ProcessDataOnline(ORB_SLAM3::System *SLAM);
 

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -12,6 +12,8 @@
 #include "service/slam/v1/slam.pb.h"
 
 using grpc::ServerContext;
+using viam::service::slam::v1::GetInternalStateRequest;
+using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
 using viam::service::slam::v1::GetPointCloudMapRequest;
@@ -20,8 +22,6 @@ using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
-using viam::service::slam::v1::GetInternalStateRequest;
-using viam::service::slam::v1::GetInternalStateResponse;
 using viam::service::slam::v1::SLAMService;
 using SlamPtr = std::unique_ptr<ORB_SLAM3::System>;
 
@@ -55,9 +55,9 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerContext *context, const GetPointCloudMapRequest *request,
         GetPointCloudMapResponse *response) override;
 
-   ::grpc::Status GetInternalState(ServerContext *context,
-                                       const GetInternalStateRequest *request,
-                                       GetInternalStateResponse *response) override;
+    ::grpc::Status GetInternalState(
+        ServerContext *context, const GetInternalStateRequest *request,
+        GetInternalStateResponse *response) override;
 
     void ProcessDataOnline(ORB_SLAM3::System *SLAM);
 
@@ -73,9 +73,8 @@ class SLAMServiceImpl final : public SLAMService::Service {
 
     void StopSaveAtlasAsOsa();
 
-    void SetSlam(ORB_SLAM3::System* s);
+    void SetSlam(ORB_SLAM3::System *s);
     bool ArchiveSlam(std::stringbuf &buffer);
-
 
     string path_to_data;
     string path_to_map;
@@ -99,14 +98,13 @@ class SLAMServiceImpl final : public SLAMService::Service {
     int n_key_frames = 0;
     int curr_map_id = 0;
 
-
    private:
     void SaveAtlasAsOsaWithTimestamp(ORB_SLAM3::System *SLAM);
 
     std::atomic<bool> finished_processing_offline{false};
     std::thread *thread_save_atlas_as_osa_with_timestamp;
 
-    ORB_SLAM3::System* slam;
+    ORB_SLAM3::System *slam;
     std::mutex slam_mutex;
     Sophus::SE3f poseGrpc;
     std::vector<ORB_SLAM3::MapPoint *> currMapPoints;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1.h
@@ -37,6 +37,10 @@ class SLAMServiceImpl final : public SLAMService::Service {
                                const GetPositionRequest *request,
                                GetPositionResponse *response) override;
 
+    // For a given GetPositionNewRequest
+    // Returns a GetPositionNewResponse containing
+    // the current pose and component_reference of the SLAM
+    // sensor.
     ::grpc::Status GetPositionNew(ServerContext *context,
                                   const GetPositionNewRequest *request,
                                   GetPositionNewResponse *response) override;
@@ -44,17 +48,18 @@ class SLAMServiceImpl final : public SLAMService::Service {
     ::grpc::Status GetMap(ServerContext *context, const GetMapRequest *request,
                           GetMapResponse *response) override;
 
-    /*
-      For a given GetPointCloudMapRequest
-      Returns a GetPointCloudMapResponse containing a sparse
-      slam map as Binary PCD
-
-      Map uses z axis is in the direction the camera is facing
-    */
+    // For a given GetPointCloudMapRequest
+    // Returns a GetPointCloudMapResponse containing a sparse
+    // slam map as Binary PCD
+    // Map uses z axis is in the direction the camera is facing
     ::grpc::Status GetPointCloudMap(
         ServerContext *context, const GetPointCloudMapRequest *request,
         GetPointCloudMapResponse *response) override;
 
+    // For a given GetInternalStateRequest
+    // Returns a GetInternalStateResponse containing
+    // the internal state of the SLAM algorithm
+    // required to continue mapping/localization
     ::grpc::Status GetInternalState(
         ServerContext *context, const GetInternalStateRequest *request,
         GetInternalStateResponse *response) override;

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
         SLAM->GetAtlas()->ChangeMap(largestMap);
     }
 
-    // slamService.SetSlam(SLAM.get());
+    slamService.SetSlam(SLAM.get());
     if (!slamService.use_live_data) {
         BOOST_LOG_TRIVIAL(info) << "Running in offline mode";
         slamService.StartSaveAtlasAsOsa(SLAM.get());

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -16,7 +16,6 @@
 using namespace boost::filesystem;
 using grpc::Server;
 using grpc::ServerBuilder;
-using SlamPtr = std::unique_ptr<ORB_SLAM3::System>;
 
 void exit_loop_handler(int s) {
     BOOST_LOG_TRIVIAL(info) << "Finishing session";
@@ -170,6 +169,7 @@ int main(int argc, char **argv) {
         SLAM->GetAtlas()->ChangeMap(largestMap);
     }
 
+    // slamService.SetSlam(SLAM.get());
     if (!slamService.use_live_data) {
         BOOST_LOG_TRIVIAL(info) << "Running in offline mode";
         slamService.StartSaveAtlasAsOsa(SLAM.get());

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -189,6 +189,7 @@ int main(int argc, char **argv) {
     }
     // slamService.ProcessDataForTesting(SLAM.get());
 
+    slamService.SetSlam(nullptr);
     SLAM->Shutdown();
     BOOST_LOG_TRIVIAL(info) << "System shutdown";
 

--- a/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/slam-libraries/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -35,6 +35,7 @@ int main(int argc, char **argv) {
     sigaction(SIGINT, &sigHandler, NULL);
 
     viam::SLAMServiceImpl slamService;
+    slamService.SetSlam(nullptr);
 
     try {
         const vector<string> args(argv + 1, argv + argc);


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-1063)


NOTE: Depending on approval of the scope doc to make GetInternalState & GetPointCloudMap server streaming endpoints, this PR may need a follow-up PR to refactor into a server streaming API before considering the ticket complete. 

Tested with:
```bash
grpcurl -max-msg-sz 320000000  -d '{"name": "run-slam"}'  -plaintext -protoset <(~/slam-clone/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep orb_grpc_serv | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetInternalState | jq -r '.internalState' | base64 -d > orb_internal_state.osa
```

Depends on https://github.com/viamrobotics/ORB_SLAM3/pull/7 to add `DumpOsa` to `ORB_SLAM3::System`


Testing steps (from @JohnN193  thank you!):
```
Localization Mode. 
This assumes localization mode will return the state of the map, even before localization has occurred.

This verifies that all the slam state needed to run Orbslam was contained within the GetInternalState response.

1. Do an initial run with no initial map. The config should use live data. Data rate_msec should be set to 200
2. GetPointCloudMap & persist to PCD file, GetInternalState & persist to file
3. Stop RDK
4. Move the file to the maps directory, with the same name as the most recently written map file with the current timestamp.
5. Start RDK
6. Confirm you see `Initialization of Atlas from file` with the file you copied into the map directory.
7. Confirm Orbslam does not crash & you are able to get a successful response from GetPointCloudMap
```

I ran through the testing steps above this PR passes them.