### PR TITLE
RSDK-1732 Don't Save Map On Closeout (live mode/ unfinished data)

### DIFF
--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -635,6 +635,12 @@ void SLAMServiceImpl::SaveMapWithTimestamp() {
             return;
         }
 
+        // Breakout without svaing if you aren't in offline mode or haven't 
+        // finished processing the data
+        if (!b_continue_session) {
+            break;
+        }
+
         std::lock_guard<std::mutex> lk(map_builder_mutex);
         map_builder.SaveMapToFile(true, filename_with_timestamp);
     }


### PR DESCRIPTION
This PR adds a small fix to stop maps from being saved upon closeout if SLAM is being run in live mode or in offline mode when the data has yet to be completely processed.

JIRA Ticket: [RSDK-1732](https://viam.atlassian.net/browse/RSDK-1732)