### PR TITLE
[RSDK-1955] Add GetInternalStateStream to cartographer

### DIFF
--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -9,8 +9,8 @@ bufsetup:
 	pkg-config openssl || export PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:`find \`which brew > /dev/null && brew --prefix\` -name openssl.pc | head -n1 | xargs dirname`
 
 buf: bufsetup
-	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/viamrobotics/api
-	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.grpc.gen.yaml buf.build/viamrobotics/api
+	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml https://github.com/nicksanford/api.git
+	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.grpc.gen.yaml https://github.com/nicksanford/api.git
 	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/googleapis/googleapis
 
 clean-all: cleanorb cleancarto

--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -9,8 +9,8 @@ bufsetup:
 	pkg-config openssl || export PKG_CONFIG_PATH=$$PKG_CONFIG_PATH:`find \`which brew > /dev/null && brew --prefix\` -name openssl.pc | head -n1 | xargs dirname`
 
 buf: bufsetup
-	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml https://github.com/nicksanford/api.git
-	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.grpc.gen.yaml https://github.com/nicksanford/api.git
+	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/viamrobotics/api
+	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.grpc.gen.yaml buf.build/viamrobotics/api
 	PATH="${PATH}:`pwd`/grpc/bin" buf generate --template ./buf.gen.yaml buf.build/googleapis/googleapis
 
 clean-all: cleanorb cleancarto

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -317,7 +317,9 @@ std::atomic<bool> b_continue_session{true};
             buf.substr(start_index, maximumGRPCByteChunkSize);
         response.set_internal_state_chunk(internal_state_chunk);
         bool ok = writer->Write(response);
-        if (!ok) return grpc::Status(grpc::StatusCode::UNAVAILABLE, "error while writing to stream: stream closed");
+        if (!ok)
+            return grpc::Status(grpc::StatusCode::UNAVAILABLE,
+                                "error while writing to stream: stream closed");
     }
 
     return grpc::Status::OK;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -280,16 +280,16 @@ std::atomic<bool> b_continue_session{true};
 // painted map, using probability estimates
 ::grpc::Status SLAMServiceImpl::GetPointCloudMapStream(
     ServerContext *context, const GetPointCloudMapStreamRequest *request,
-    ServerWriter<GetPointCloudMapStreamResponse> *writer){
-        return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
-    }
+    ServerWriter<GetPointCloudMapStreamResponse> *writer) {
+    return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
 
 // GetInternalState returns the current internal state of the map which is
-    // a pbstream for cartographer. The internal state is streamed in chunks of size maximumGRPCByteChunkSize
+// a pbstream for cartographer. The internal state is streamed in chunks of size
+// maximumGRPCByteChunkSize
 ::grpc::Status SLAMServiceImpl::GetInternalStateStream(
     ServerContext *context, const GetInternalStateStreamRequest *request,
-    ServerWriter<GetInternalStateStreamResponse>* writer){
-
+    ServerWriter<GetInternalStateStreamResponse> *writer) {
     boost::uuids::uuid uuid = boost::uuids::random_generator()();
     std::string filename = path_to_map + "/" + "temp_internal_state_" +
                            boost::uuids::to_string(uuid) + ".pbstream";
@@ -314,8 +314,10 @@ std::atomic<bool> b_continue_session{true};
 
     std::string internal_state_chunk;
     GetInternalStateStreamResponse response;
-    for (int start_index = 0; start_index < buf.size(); start_index += maximumGRPCByteChunkSize) {
-        internal_state_chunk = buf.substr(start_index, maximumGRPCByteChunkSize);
+    for (int start_index = 0; start_index < buf.size();
+         start_index += maximumGRPCByteChunkSize) {
+        internal_state_chunk =
+            buf.substr(start_index, maximumGRPCByteChunkSize);
         response.set_internal_state_chunk(internal_state_chunk);
         writer->Write(response);
     }

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -304,7 +304,8 @@ std::atomic<bool> b_continue_session{true};
     }
 
     std::string buf;
-    // deferring reading the pbstream file in chunks until we run into issues with loading the file into memory
+    // deferring reading the pbstream file in chunks until we run into issues
+    // with loading the file into memory
     try {
         ConvertSavedMapToStream(filename, &buf);
     } catch (std::exception &e) {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -304,6 +304,7 @@ std::atomic<bool> b_continue_session{true};
     }
 
     std::string buf;
+    // deferring reading the pbstream file in chunks until we run into issues with loading the file into memory
     try {
         ConvertSavedMapToStream(filename, &buf);
     } catch (std::exception &e) {

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -285,7 +285,7 @@ std::atomic<bool> b_continue_session{true};
     }
 
 // GetInternalState returns the current internal state of the map which is
-// a pbstream for cartographer.
+    // a pbstream for cartographer. The internal state is streamed in chunks of size maximumGRPCByteChunkSize
 ::grpc::Status SLAMServiceImpl::GetInternalStateStream(
     ServerContext *context, const GetInternalStateStreamRequest *request,
     ServerWriter<GetInternalStateStreamResponse>* writer){

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -276,17 +276,12 @@ std::atomic<bool> b_continue_session{true};
     }
 }
 
-// GetPointCloudMap returns the current sampled pointcloud derived from the
-// painted map, using probability estimates
 ::grpc::Status SLAMServiceImpl::GetPointCloudMapStream(
     ServerContext *context, const GetPointCloudMapStreamRequest *request,
     ServerWriter<GetPointCloudMapStreamResponse> *writer) {
     return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-// GetInternalState returns the current internal state of the map which is
-// a pbstream for cartographer. The internal state is streamed in chunks of size
-// maximumGRPCByteChunkSize
 ::grpc::Status SLAMServiceImpl::GetInternalStateStream(
     ServerContext *context, const GetInternalStateStreamRequest *request,
     ServerWriter<GetInternalStateStreamResponse> *writer) {
@@ -321,7 +316,8 @@ std::atomic<bool> b_continue_session{true};
         internal_state_chunk =
             buf.substr(start_index, maximumGRPCByteChunkSize);
         response.set_internal_state_chunk(internal_state_chunk);
-        writer->Write(response);
+        bool ok = writer->Write(response);
+        if (!ok) return grpc::Status(grpc::StatusCode::UNAVAILABLE, "error while writing to stream: stream closed");
     }
 
     return grpc::Status::OK;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -52,10 +52,8 @@ static const unsigned char defaultCairosEmptyPaintedSlice = 102;
 static const int jpegQuality = 50;
 // Byte limit on GRPC, used to help determine sampling skip_count
 static const int maximumGRPCByteLimit = 32 * 1024 * 1024;
-
 // Byte limit for chunks on GRPC, used for streaming apis
 static const int maximumGRPCByteChunkSize = 64000;
-
 // Coeffient to adjust the skip count for the PCD to ensure the file is within
 // grpc limitations. Increase the value if you expect dense feature-rich maps
 static const int samplingFactor = 1;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -22,26 +22,26 @@
 #include "service/slam/v1/slam.pb.h"
 
 using google::protobuf::Struct;
+using grpc::ServerContext;
 using grpc::ServerWriter;
 using viam::common::v1::PointCloudObject;
 using viam::common::v1::Pose;
 using viam::common::v1::PoseInFrame;
 using viam::service::slam::v1::GetInternalStateRequest;
 using viam::service::slam::v1::GetInternalStateResponse;
+using viam::service::slam::v1::GetInternalStateStreamRequest;
+using viam::service::slam::v1::GetInternalStateStreamResponse;
 using viam::service::slam::v1::GetMapRequest;
 using viam::service::slam::v1::GetMapResponse;
 using viam::service::slam::v1::GetPointCloudMapRequest;
 using viam::service::slam::v1::GetPointCloudMapResponse;
+using viam::service::slam::v1::GetPointCloudMapStreamRequest;
+using viam::service::slam::v1::GetPointCloudMapStreamResponse;
 using viam::service::slam::v1::GetPositionNewRequest;
 using viam::service::slam::v1::GetPositionNewResponse;
 using viam::service::slam::v1::GetPositionRequest;
 using viam::service::slam::v1::GetPositionResponse;
 using viam::service::slam::v1::SLAMService;
-using viam::service::slam::v1::GetInternalStateStreamRequest;
-using viam::service::slam::v1::GetInternalStateStreamResponse;
-using viam::service::slam::v1::GetPointCloudMapStreamRequest;
-using viam::service::slam::v1::GetPointCloudMapStreamResponse;
-using grpc::ServerContext;
 
 namespace viam {
 
@@ -121,10 +121,11 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerWriter<GetPointCloudMapStreamResponse> *writer) override;
 
     // GetInternalState returns the current internal state of the map which is
-    // a pbstream for cartographer. The internal state is streamed in chunks of size maximumGRPCByteChunkSize
+    // a pbstream for cartographer. The internal state is streamed in chunks of
+    // size maximumGRPCByteChunkSize
     ::grpc::Status GetInternalStateStream(
         ServerContext *context, const GetInternalStateStreamRequest *request,
-        ServerWriter<GetInternalStateStreamResponse>* writer) override;
+        ServerWriter<GetInternalStateStreamResponse> *writer) override;
 
     // RunSLAM sets up and runs cartographer. It runs cartographer in
     // the ActionMode mode: Either creating

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -53,7 +53,7 @@ static const int jpegQuality = 50;
 // Byte limit on GRPC, used to help determine sampling skip_count
 static const int maximumGRPCByteLimit = 32 * 1024 * 1024;
 // Byte limit for chunks on GRPC, used for streaming apis
-static const int maximumGRPCByteChunkSize = 64000;
+static const int maximumGRPCByteChunkSize = 64 * 1024;
 // Coeffient to adjust the skip count for the PCD to ensure the file is within
 // grpc limitations. Increase the value if you expect dense feature-rich maps
 static const int samplingFactor = 1;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -112,15 +112,14 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerContext *context, const GetInternalStateRequest *request,
         GetInternalStateResponse *response) override;
 
-    // GetPointCloudMap returns the current sampled pointcloud derived from the
-    // painted map, using probability estimates
+    // GetPointCloudMap returns a stream of the current sampled pointcloud derived from the
+    // painted map, using probability estimates in chunks with a max size of maximumGRPCByteChunkSize
     ::grpc::Status GetPointCloudMapStream(
         ServerContext *context, const GetPointCloudMapStreamRequest *request,
         ServerWriter<GetPointCloudMapStreamResponse> *writer) override;
 
-    // GetInternalState returns the current internal state of the map which is
-    // a pbstream for cartographer. The internal state is streamed in chunks of
-    // size maximumGRPCByteChunkSize
+    // GetInternalState returns a stream of the current internal state of the map which is
+    // a pbstream for cartographer in chunks of size maximumGRPCByteChunkSize
     ::grpc::Status GetInternalStateStream(
         ServerContext *context, const GetInternalStateStreamRequest *request,
         ServerWriter<GetInternalStateStreamResponse> *writer) override;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -53,8 +53,8 @@ static const int jpegQuality = 50;
 // Byte limit on GRPC, used to help determine sampling skip_count
 static const int maximumGRPCByteLimit = 32 * 1024 * 1024;
 
-// Byte limit on GRPC, used to help determine sampling skip_count
-static const int maximumGRPCByteChunkSize = 32 * 1024 * 1024;
+// Byte limit for chunks on GRPC, used for streaming apis
+static const int maximumGRPCByteChunkSize = 64000;
 
 // Coeffient to adjust the skip count for the PCD to ensure the file is within
 // grpc limitations. Increase the value if you expect dense feature-rich maps
@@ -121,7 +121,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerWriter<GetPointCloudMapStreamResponse> *writer) override;
 
     // GetInternalState returns the current internal state of the map which is
-    // a pbstream for cartographer.
+    // a pbstream for cartographer. The internal state is streamed in chunks of size maximumGRPCByteChunkSize
     ::grpc::Status GetInternalStateStream(
         ServerContext *context, const GetInternalStateStreamRequest *request,
         ServerWriter<GetInternalStateStreamResponse>* writer) override;

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -112,14 +112,16 @@ class SLAMServiceImpl final : public SLAMService::Service {
         ServerContext *context, const GetInternalStateRequest *request,
         GetInternalStateResponse *response) override;
 
-    // GetPointCloudMap returns a stream of the current sampled pointcloud derived from the
-    // painted map, using probability estimates in chunks with a max size of maximumGRPCByteChunkSize
+    // GetPointCloudMap returns a stream of the current sampled pointcloud
+    // derived from the painted map, using probability estimates in chunks with
+    // a max size of maximumGRPCByteChunkSize
     ::grpc::Status GetPointCloudMapStream(
         ServerContext *context, const GetPointCloudMapStreamRequest *request,
         ServerWriter<GetPointCloudMapStreamResponse> *writer) override;
 
-    // GetInternalState returns a stream of the current internal state of the map which is
-    // a pbstream for cartographer in chunks of size maximumGRPCByteChunkSize
+    // GetInternalState returns a stream of the current internal state of the
+    // map which is a pbstream for cartographer in chunks of size
+    // maximumGRPCByteChunkSize
     ::grpc::Status GetInternalStateStream(
         ServerContext *context, const GetInternalStateStreamRequest *request,
         ServerWriter<GetInternalStateStreamResponse> *writer) override;


### PR DESCRIPTION
Part 1 of several on [RSDK-1955](https://viam.atlassian.net/browse/RSDK-1955?atlOrigin=eyJpIjoiYjdmMjUwYTJlNzM2NDNiNzk1MTM0M2JmMWY2NDJhZWIiLCJwIjoiaiJ9) This implements `GetInternalStateStream` for the cartographer grpc server. Additionally adds `GetPointCloudMapStream` as unimplemented

Tested using grpcurl and the script to extract chunks from the output that Nick wrote. I made a `GetInternalStateStream` request and formatted the `pbstream` to be injected into cartographer. Cartographer was able to use the internal state.

TESTING:
Tested using this [dataset]( https://drive.google.com/file/d/1w9l4XzJwyKXXgWs8XIhKgIlhzAv6UlMU/view?usp=share_link)
run running viam-server using this [robot](https://app.viam.com/robot?id=2fda0155-ee9c-4f6e-a08f-588796da2ee2&tab=config%2Cservices) 
after run was completed, I requested the internal state and wrote it to a .pbstream file
`../go/bin/grpcurl -max-msg-sz 10000000 -d '{"name": "slam"}' -plaintext -protoset <(~/slam/slam-libraries/grpc/bin/buf build -o -) $(sudo netstat -tulpn | grep LISTEN | grep carto_grpc_se | awk '{print $4}' | sort | head -n 1) viam.service.slam.v1.SLAMService/GetInternalStateStream | jq -r ".internalStateChunk"  | ./base64_decode_lines.py > t map_data_2023-02-09T19:17:07.0000Z.pbstream`
I then ran the viam-server using the apriori map

```
2023-02-17T21:44:53.186Z	ERROR	robot_server.process.slam_cartographer_carto_grpc_server.StdErr	pexec/managed_process.go:219	
\_ I0217 21:44:53.181030 11785 slam_service_helpers.cc:41] Running in localization only mode
2023-02-17T21:44:53.186Z	ERROR	robot_server.process.slam_cartographer_carto_grpc_server.StdErr	pexec/managed_process.go:219	
\_ I0217 21:44:53.181130 11785 map_builder.cc:394] Loading saved state '/home/johnn193/localization_test2/map/map_data_2023-02-09T19:17:07.0000Z.pbstream'...
2023-02-17T21:44:53.192Z	ERROR	robot_server	impl/resource_manager.go:402	error building component	{"resource": "rdk:component:camera/rplidar", "model": "viam:lidar:rplidar", "error": "rpc error: code = Unknown desc = need to specify a devicePath (ex. /dev/ttyUSB0): no usb devices found"}
2023-02-17T21:44:56.887Z	INFO	robot_server	rpc/server.go:515	will run external signaling answerer	{"signaling_address": "app.viam.com:443", "for_hosts": ["john-pi-main.ytxdza0q92.viam.cloud"]}
2023-02-17T21:44:56.947Z	INFO	robot_server	web/web.go:811	serving	{"url": "https://john-pi-main.ytxdza0q92.local.viam.cloud:8080", "alt_url": "https://0.0.0.0:8080"}
2023-02-17T21:45:07.840Z	ERROR	robot_server.process.slam_cartographer_carto_grpc_server.StdErr	pexec/managed_process.go:219	
\_ I0217 21:45:07.840821 11785 slam_service.cc:745] Starting to run cartographer
```
which shows the pbstream was not corrupted when streamed by the server

[RSDK-1955]: https://viam.atlassian.net/browse/RSDK-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ