### PR TITLE
RSDK-1970 Cartographer First Time Install Issues on MacOS

### DIFF
--- a/slam-libraries/viam-cartographer/CMakeLists.txt
+++ b/slam-libraries/viam-cartographer/CMakeLists.txt
@@ -25,9 +25,6 @@ link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
 find_package(OpenSSL REQUIRED)
-include_directories(${OPENSSL_INCLUDE_DIRS})
-link_directories(${OPENSSL_LIBRARY_DIRS})
-add_definitions(${OPENSSL_DEFINITIONS})
 
 if(WIN32)
   # On Windows, Protobuf is incorrectly found by the bundled CMake module, so prefer native CMake config.

--- a/slam-libraries/viam-cartographer/scripts/setup_cartographer_macos.sh
+++ b/slam-libraries/viam-cartographer/scripts/setup_cartographer_macos.sh
@@ -5,3 +5,4 @@ brew install abseil boost ceres-solver protobuf ninja cairo googletest lua@5.3
 brew link lua@5.3
 brew install openssl eigen gflags glog suite-sparse sphinx-doc pcl
 brew link protobuf
+brew link openssl


### PR DESCRIPTION
This PR solves a minor problem involving openssl when installing Cartographer for the first time on a mac.

JIRA Ticket: [RSDK-1970](https://viam.atlassian.net/browse/RSDK-1970)

[RSDK-1970]: https://viam.atlassian.net/browse/RSDK-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ