### PR TITLE
RSDK-1753 - Fix localization mode

### DIFF
--- a/slam-libraries/viam-cartographer/lua_files/locating_in_map.lua
+++ b/slam-libraries/viam-cartographer/lua_files/locating_in_map.lua
@@ -1,7 +1,10 @@
 include "trajectory_builder.lua"
 include "map_builder.lua"
 
--- ++++ ALWAYS TRY TO TUNE FOR A PLATFORM, NOT A PARTICULAR BAG ++++ --
+-- !!!!! NOTE: DO NOT CHANGE THIS FILE !!!!! --
+
+-- ALWAYS TRY TO TUNE FOR A SENSOR SET/ROBOT SETUP,
+-- NOT A PARTICULAR ENVIRONMENT --
 
 -- ===== Local SLAM Options ======
 -- no reason to change these:

--- a/slam-libraries/viam-cartographer/lua_files/mapping_new_map.lua
+++ b/slam-libraries/viam-cartographer/lua_files/mapping_new_map.lua
@@ -1,7 +1,10 @@
 include "trajectory_builder.lua"
 include "map_builder.lua"
 
--- ++++ ALWAYS TRY TO TUNE FOR A PLATFORM, NOT A PARTICULAR BAG ++++ --
+-- !!!!! NOTE: DO NOT CHANGE THIS FILE !!!!! --
+
+-- ALWAYS TRY TO TUNE FOR A SENSOR SET/ROBOT SETUP,
+-- NOT A PARTICULAR ENVIRONMENT --
 
 -- ===== Local SLAM Options ======
 -- no reason to change these:

--- a/slam-libraries/viam-cartographer/lua_files/updating_a_map.lua
+++ b/slam-libraries/viam-cartographer/lua_files/updating_a_map.lua
@@ -1,7 +1,10 @@
 include "trajectory_builder.lua"
 include "map_builder.lua"
 
--- ++++ ALWAYS TRY TO TUNE FOR A PLATFORM, NOT A PARTICULAR BAG ++++ --
+-- !!!!! NOTE: DO NOT CHANGE THIS FILE !!!!! --
+
+-- ALWAYS TRY TO TUNE FOR A SENSOR SET/ROBOT SETUP,
+-- NOT A PARTICULAR ENVIRONMENT --
 
 -- ===== Local SLAM Options ======
 -- no reason to change these:

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -755,11 +755,13 @@ void SLAMServiceImpl::PaintMarker(
     viam::io::DrawPoseOnSurface(painted_slices, global_pose, kPixelSize);
 }
 
-void SLAMServiceImpl::RunSLAM() {
-    LOG(INFO) << "Setting up cartographer";
+
+void SetUpSLAM() {
+    // Setting the action mode has to happen before setting up the
+    // map builder.
+    SetActionMode();
     // Set up and build the MapBuilder
     SetUpMapBuilder();
-    SetActionMode();
 
     double data_start_time = 0;
     if (action_mode == ActionMode::UPDATING ||
@@ -793,7 +795,11 @@ void SLAMServiceImpl::RunSLAM() {
 
         CacheMapInLocalizationMode();
     }
+}
 
+void SLAMServiceImpl::RunSLAM() {
+    LOG(INFO) << "Setting up cartographer";
+    SetUpSLAM();
     LOG(INFO) << "Starting to run cartographer";
     ProcessDataAndStartSavingMaps(data_start_time);
     LOG(INFO) << "Done running cartographer";

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -755,7 +755,7 @@ void SLAMServiceImpl::PaintMarker(
     viam::io::DrawPoseOnSurface(painted_slices, global_pose, kPixelSize);
 }
 
-int SLAMServiceImpl::SetUpSLAM() {
+double SLAMServiceImpl::SetUpSLAM() {
     // Setting the action mode has to happen before setting up the
     // map builder.
     SetActionMode();
@@ -799,7 +799,7 @@ int SLAMServiceImpl::SetUpSLAM() {
 
 void SLAMServiceImpl::RunSLAM() {
     LOG(INFO) << "Setting up cartographer";
-    int data_start_time = SetUpSLAM();
+    double data_start_time = SetUpSLAM();
     LOG(INFO) << "Starting to run cartographer";
     ProcessDataAndStartSavingMaps(data_start_time);
     LOG(INFO) << "Done running cartographer";

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.cc
@@ -755,8 +755,7 @@ void SLAMServiceImpl::PaintMarker(
     viam::io::DrawPoseOnSurface(painted_slices, global_pose, kPixelSize);
 }
 
-
-void SetUpSLAM() {
+int SLAMServiceImpl::SetUpSLAM() {
     // Setting the action mode has to happen before setting up the
     // map builder.
     SetActionMode();
@@ -795,11 +794,12 @@ void SetUpSLAM() {
 
         CacheMapInLocalizationMode();
     }
+    return data_start_time;
 }
 
 void SLAMServiceImpl::RunSLAM() {
     LOG(INFO) << "Setting up cartographer";
-    SetUpSLAM();
+    int data_start_time = SetUpSLAM();
     LOG(INFO) << "Starting to run cartographer";
     ProcessDataAndStartSavingMaps(data_start_time);
     LOG(INFO) << "Done running cartographer";

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -254,8 +254,14 @@ class SLAMServiceImpl final : public SLAMService::Service {
     void ProcessDataAndStartSavingMaps(double data_cutoff_time);
 
     // SetUpMapBuilder loads the lua file with default cartographer config
-    // parameters depending on the action mode.
+    // parameters depending on the action mode. Setting the correct action
+    // mode has to happen before calling this function.
     void SetUpMapBuilder();
+
+    // SetUpSLAM sets the correct action mode, prepares the map builder and
+    // loads the right hyperparameters based on the action mode. Needs to be
+    // called before running slam. 
+    void SetUpSLAM();
 
     // GetLatestPaintedMapSlices paints and returns the current map of
     // Cartographer

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -261,7 +261,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
     // SetUpSLAM sets the correct action mode, prepares the map builder and
     // loads the right hyperparameters based on the action mode. Needs to be
     // called before running slam.
-    int SetUpSLAM();
+    double SetUpSLAM();
 
     // GetLatestPaintedMapSlices paints and returns the current map of
     // Cartographer

--- a/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
+++ b/slam-libraries/viam-cartographer/src/slam_service/slam_service.h
@@ -260,8 +260,8 @@ class SLAMServiceImpl final : public SLAMService::Service {
 
     // SetUpSLAM sets the correct action mode, prepares the map builder and
     // loads the right hyperparameters based on the action mode. Needs to be
-    // called before running slam. 
-    void SetUpSLAM();
+    // called before running slam.
+    int SetUpSLAM();
 
     // GetLatestPaintedMapSlices paints and returns the current map of
     // Cartographer


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-1753

* Fixes localization mode and updating mode

Works decently well with an A3 and the following config:

```json
{
  "services": [
    {
      "name": "run-online-slam-test",
      "model": "cartographer",
      "type": "slam",
      "attributes": {
        "port": "localhost:8083",
        "data_dir": "YOUR_DATA_DIRECTORY",
        "delete_processed_data": true,
        "use_live_data": true,
        "map_rate_sec": 0,
        "sensors": [
          "rplidar"
        ],
        "config_params": {
          "optimize_on_start": "true",
          "num_range_data": "100",
          "mode": "2d",
          "max_submaps_to_keep": "2"
        }
      }
    }
  ],
  "modules": [
    {
      "name": "rplidar_module",
      "executable_path": "/usr/local/bin/rplidar-module"
    }
  ],
  "components": [
    {
      "depends_on": [],
      "model": "viam:lidar:rplidar",
      "attributes": {
        "device_path": "/dev/tty.SLAB_USBtoUART"
      },
      "name": "rplidar",
      "namespace": "rdk",
      "type": "camera"
    }
  ]
}
```