### PR TITLE
Define ABSL_LEGACY_THREAD_ANNOTATIONS

### DIFF
--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -95,7 +95,7 @@ testcarto:
 	cd viam-cartographer && ./scripts/test_cartographer.sh
 
 installcarto:
-	sudo cp ./viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
+	sudo cp viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
 
 installorb:
 	sudo cp viam-orb-slam3/bin/orb_grpc_server /usr/local/bin/orb_grpc_server

--- a/slam-libraries/Makefile
+++ b/slam-libraries/Makefile
@@ -94,6 +94,12 @@ install-lua-carto:
 testcarto:
 	cd viam-cartographer && ./scripts/test_cartographer.sh
 
+installcarto:
+	sudo cp ./viam-cartographer/build/carto_grpc_server /usr/local/bin/carto_grpc_server
+
+installorb:
+	sudo cp viam-orb-slam3/bin/orb_grpc_server /usr/local/bin/orb_grpc_server
+
 carto-all: bufinstall buf setupcarto buildcarto install-lua-carto testcarto
 
 include *.make

--- a/slam-libraries/viam-cartographer/CMakeLists.txt
+++ b/slam-libraries/viam-cartographer/CMakeLists.txt
@@ -10,6 +10,7 @@ set(VIAM_CARTOGRAPHER_SOVERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MIN
 
 include("${PROJECT_SOURCE_DIR}/cmake/functions.cmake")
 
+add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
 find_package(absl REQUIRED)
 find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
 find_package(Lua 5.2 REQUIRED)

--- a/slam-libraries/viam-cartographer/CMakeLists.txt
+++ b/slam-libraries/viam-cartographer/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(viam-cartographer)
+add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
 
 set(VIAM_CARTOGRAPHER_MAJOR_VERSION 1)
 set(VIAM_CARTOGRAPHER_MINOR_VERSION 0)
@@ -10,7 +11,6 @@ set(VIAM_CARTOGRAPHER_SOVERSION ${CARTOGRAPHER_MAJOR_VERSION}.${CARTOGRAPHER_MIN
 
 include("${PROJECT_SOURCE_DIR}/cmake/functions.cmake")
 
-add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
 find_package(absl REQUIRED)
 find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
 find_package(Lua 5.2 REQUIRED)

--- a/slam-libraries/viam-cartographer/cartographer_build_utils/CMakeLists.txt
+++ b/slam-libraries/viam-cartographer/cartographer_build_utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 
 project(cartographer)
+add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
 
 set(CARTOGRAPHER_MAJOR_VERSION 1)
 set(CARTOGRAPHER_MINOR_VERSION 0)

--- a/slam-libraries/viam-cartographer/scripts/build_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/build_cartographer.sh
@@ -18,7 +18,8 @@ rm -rf build
 mkdir build
 pushd build
 
-cmake .. -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=`brew --prefix` -DABSL_LEGACY_THREAD_ANNOTATIONS=1
+echo building cartogropher
+cmake .. -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=`brew --prefix`
 ninja
 popd
 popd

--- a/slam-libraries/viam-cartographer/scripts/build_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/build_cartographer.sh
@@ -18,7 +18,7 @@ rm -rf build
 mkdir build
 pushd build
 
-cmake .. -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=`brew --prefix`
+cmake .. -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=`brew --prefix` -DABSL_LEGACY_THREAD_ANNOTATIONS=1
 ninja
 popd
 popd

--- a/slam-libraries/viam-cartographer/scripts/build_viam_cartographer.sh
+++ b/slam-libraries/viam-cartographer/scripts/build_viam_cartographer.sh
@@ -22,6 +22,7 @@ fi
 
 pushd build
 
+echo building viam cartogropher
 cmake .. -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=`brew --prefix` -DQt5_DIR=$(brew --prefix qt5)/lib/cmake/Qt5
 ninja
 popd

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -2,7 +2,6 @@
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
 #include <signal.h>
-#define ABSL_LEGACY_THREAD_ANNOTATIONS
 
 #include <iostream>
 #include <thread>

--- a/slam-libraries/viam-cartographer/src/main.cc
+++ b/slam-libraries/viam-cartographer/src/main.cc
@@ -2,6 +2,7 @@
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>
 #include <signal.h>
+#define ABSL_LEGACY_THREAD_ANNOTATIONS
 
 #include <iostream>
 #include <thread>


### PR DESCRIPTION
- Define `ABSL_LEGACY_THREAD_ANNOTATIONS` in CMake pipeline so cartographer continues to build with absl version `20230125.1` and greater: https://github.com/abseil/abseil-cpp/releases.

I've tested this by running:
```bash
make cartoclean && make buf && make buildcarto && make installcarto
```

It compiles just fine on both.

I then ran cartogropher in mapping / updating mode on both mac & linux with those compiled grpc servers & they appeared to work on both platforms. I updated the map for about 5 min & rendered the map in the RDK control UI.