### PR TITLE
RSDK-2435 Remove Dev Flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,6 @@ type AttrConfig struct {
 	MapRateSec          *int              `json:"map_rate_sec"`
 	Port                string            `json:"port"`
 	DeleteProcessedData *bool             `json:"delete_processed_data"`
-	Dev                 bool              `json:"dev"`
 }
 
 // NewAttrConfig creates a SLAM config from a service config.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -150,7 +150,6 @@ func TestNewAttrConf(t *testing.T) {
 		cfgService.Attributes["map_rate_sec"] = 1002
 		cfgService.Attributes["port"] = "47"
 		cfgService.Attributes["delete_processed_data"] = true
-		cfgService.Attributes["dev"] = false
 
 		cfgService.Attributes["config_params"] = map[string]string{
 			"mode":    "test mode",
@@ -165,7 +164,6 @@ func TestNewAttrConf(t *testing.T) {
 		test.That(t, cfg.DataRateMsec, test.ShouldEqual, cfgService.Attributes["data_rate_msec"])
 		test.That(t, *cfg.MapRateSec, test.ShouldEqual, cfgService.Attributes["map_rate_sec"])
 		test.That(t, cfg.Port, test.ShouldEqual, cfgService.Attributes["port"])
-		test.That(t, cfg.Dev, test.ShouldEqual, cfgService.Attributes["dev"])
 		test.That(t, cfg.ConfigParams, test.ShouldResemble, cfgService.Attributes["config_params"])
 	})
 }


### PR DESCRIPTION
Remove the unused dev flag in SLAM Map Representation project. Similar edits were also made in the rdk, viam-cartographer, and viam-orb-slam3 repos, see associated PR.

JIRA Ticket: https://viam.atlassian.net/browse/RSDK-2435

Associated PRs: 
- https://github.com/viamrobotics/rdk/pull/2150
- https://github.com/viamrobotics/viam-orb-slam3/pull/34
- https://github.com/viamrobotics/viam-cartographer/pull/37